### PR TITLE
Add config options for specifiing text added by 'pick --expose'

### DIFF
--- a/stgit/config.py
+++ b/stgit/config.py
@@ -41,6 +41,7 @@ DEFAULTS = [
     ('stgit.shortnr', ['5']),
     ('stgit.smtpdelay', ['5']),
     ('stgit.smtpserver', ['localhost:25']),
+    ('stgit.pick.expose-format', ['format:%B%n(imported from commit %H)']),
 ]
 
 

--- a/t/t3401-pick-commit.sh
+++ b/t/t3401-pick-commit.sh
@@ -20,6 +20,8 @@ test_expect_success \
     git add a.txt &&
     git commit -m "more" &&
     git rev-parse HEAD > more-msg-hash.txt &&
+    git commit -m "one" -m "two" -m "three" --allow-empty &&
+    git rev-parse HEAD > multi-line-msg-hash.txt &&
     git checkout master
     '
 
@@ -35,6 +37,110 @@ test_expect_success \
     '
     stg pick "$(cat more-msg-hash.txt)" &&
 	test "$(echo $(stg series --applied --noprefix))" = "patch more"
+    '
+
+test_expect_success \
+    'Pick with expose commit with empty message' \
+    '
+    stg delete patch more &&
+    stg pick --expose "$(cat empty-msg-hash.txt)" &&
+    test "$(echo $(stg series --applied --noprefix))" = "patch" &&
+    test_when_finished rm -f pick-expected.txt pick-message.txt &&
+    test_write_lines \
+        "" \
+        "(imported from commit $(cat empty-msg-hash.txt))" \
+        > pick-expected.txt &&
+    git show --no-patch --pretty=format:%B > pick-message.txt &&
+    test_cmp pick-expected.txt pick-message.txt
+    '
+
+test_expect_success \
+    'Pick with expose commit with non-empty message' \
+    '
+    stg pick --expose "$(cat more-msg-hash.txt)" &&
+    test "$(echo $(stg series --applied --noprefix))" = "patch more" &&
+    test_when_finished rm -f pick-expected.txt pick-message.txt &&
+    test_write_lines \
+        "more" \
+        "" \
+        "(imported from commit $(cat more-msg-hash.txt))" \
+        > pick-expected.txt &&
+    git show --no-patch --pretty=format:%B > pick-message.txt &&
+    test_cmp pick-expected.txt pick-message.txt
+    '
+
+test_expect_success \
+    'Pick with expose commit with multi-empty message' \
+    '
+    stg pick --expose "$(cat multi-line-msg-hash.txt)" &&
+    test "$(echo $(stg series --applied --noprefix))" = "patch more one" &&
+    test_when_finished rm -f pick-expected.txt pick-message.txt &&
+    test_write_lines \
+        "one" \
+        "" \
+        "two" \
+        "" \
+        "three" \
+        "" \
+        "(imported from commit $(cat multi-line-msg-hash.txt))" \
+        > pick-expected.txt &&
+    git show --no-patch --pretty=format:%B > pick-message.txt &&
+    test_cmp pick-expected.txt pick-message.txt &&
+    stg delete patch more one
+    '
+
+test_expect_success \
+    'Pick with expose custom format commit with empty message' \
+    '
+    test_config stgit.pick.expose-format %s%n%nPREFIX%n%bSUFFIX
+    stg pick --expose "$(cat empty-msg-hash.txt)" &&
+    test "$(echo $(stg series --applied --noprefix))" = "patch" &&
+    test_when_finished rm -f pick-expected.txt pick-message.txt &&
+    test_write_lines \
+        "" \
+        "" \
+        "PREFIX" \
+        "SUFFIX" \
+        > pick-expected.txt &&
+    git show --no-patch --pretty=format:%B > pick-message.txt &&
+    test_cmp pick-expected.txt pick-message.txt
+    '
+
+test_expect_success \
+    'Pick with expose custom format commit with non-empty message' \
+    '
+    test_config stgit.pick.expose-format %s%n%nPREFIX%n%bSUFFIX &&
+    stg pick --expose "$(cat more-msg-hash.txt)" &&
+    test "$(echo $(stg series --applied --noprefix))" = "patch more" &&
+    test_when_finished rm -f pick-expected.txt pick-message.txt &&
+    test_write_lines \
+        "more" \
+        "" \
+        "PREFIX" \
+        "SUFFIX" \
+        > pick-expected.txt &&
+    git show --no-patch --pretty=format:%B > pick-message.txt &&
+    test_cmp pick-expected.txt pick-message.txt
+    '
+
+test_expect_success \
+    'Pick with expose custom format commit with multi-line message' \
+    '
+    test_config stgit.pick.expose-format %s%n%nPREFIX%n%bSUFFIX &&
+    stg pick --expose "$(cat multi-line-msg-hash.txt)" &&
+    test "$(echo $(stg series --applied --noprefix))" = "patch more one" &&
+    test_when_finished rm -f pick-expected.txt pick-message.txt &&
+    test_write_lines \
+        "one" \
+        "" \
+        "PREFIX" \
+        "two" \
+        "" \
+        "three" \
+        "SUFFIX" \
+        > pick-expected.txt &&
+    git show --no-patch --pretty=format:%B > pick-message.txt &&
+    test_cmp pick-expected.txt pick-message.txt
     '
 
 test_done


### PR DESCRIPTION
Config options "stgit.pick.prepend" and "stgit.pick.append" defines
format strings for 'git show --pretty'.

Option 'stgit.pick.prepend' inserts lines after commit subject.

Default is stgit.pick.append = 'format:(imported from commit %H)'.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@yandex-team.ru>