### PR TITLE
Add "--spill" option to the refresh command that spills the content of the revision into worktree and empties its patch

### DIFF
--- a/completion/stgit.zsh
+++ b/completion/stgit.zsh
@@ -429,6 +429,7 @@ _stg-refresh() {
         '(-F --force)'{-F,--force}'[force refresh even if index is dirty]'
         '(-i --index)'{-i,--index}'[refresh from index instead of worktree]'
         '(-p --patch)'{-p,--patch=}'[refresh patch other than top patch]: :__stg_patches_applied'
+        '--spill[Spill patch contents to worktree and index, and erase patch content]'
         + '(update-files)'
         '(-u --update)'{-u,--update}'[only update current patch files]'
         '*:files:__stg_files_dirty'

--- a/t/t2704-refresh-spill.sh
+++ b/t/t2704-refresh-spill.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# shellcheck disable=SC2016
+
+test_description='Test "stg pop --spill"'
+
+. ./test-lib.sh
+
+test_expect_success 'Initialize the StGIT repository and create a patch and add some files' '
+    stg init &&
+    echo expected*.txt >> .git/info/exclude &&
+    echo patches.txt >> .git/info/exclude &&
+    echo status.txt >> .git/info/exclude &&
+    echo message.txt >> .git/info/exclude &&
+    stg new test-patch -m "Test Patch" &&
+    echo "local 0" >> patch0.txt &&
+    git add -A
+'
+
+test_expect_success 'Save current patch message to a file' '
+    stg edit --save-template=- >> expected-message.txt
+'
+
+cat > expected-patches.txt <<EOF
+EOF
+cat > expected-status.txt <<EOF
+A  patch0.txt
+EOF
+test_expect_success 'Check file status' '
+    stg status > status.txt &&
+    test_cmp expected-status.txt status.txt &&
+    stg patches patch0.txt > patches.txt &&
+    test_cmp expected-patches.txt patches.txt
+'
+
+cat > expected-patches.txt <<EOF
+test-patch
+EOF
+cat > expected-status.txt <<EOF
+EOF
+test_expect_success 'Add files to the patch' '
+    git add -A && stg refresh &&
+    stg status > status.txt &&
+    test_cmp expected-status.txt status.txt &&
+    stg patches patch0.txt > patches.txt &&
+    test_cmp expected-patches.txt patches.txt
+'
+
+test_expect_success 'Spill the topmost patch' '
+    stg refresh --spill
+'
+
+test_expect_success 'Check that topmost patch description did not change' '
+    test "$(echo $(stg top))" = "test-patch" &&
+    stg edit --save-template=- >> message.txt &&
+    test_cmp expected-message.txt message.txt
+'
+
+cat > expected-patches.txt <<EOF
+EOF
+cat > expected-status.txt <<EOF
+A  patch0.txt
+EOF
+test_expect_success 'Check that added file is no longer present in patches and changes are now in index' '
+    stg status > status.txt &&
+    test_cmp expected-status.txt status.txt
+    stg patches patch0.txt > patches.txt &&
+    test_cmp expected-patches.txt patches.txt
+'
+
+test_done


### PR DESCRIPTION
In case a user wants to completely change what goes into the patch, they can run `stg refresh --spill` and then manually add/refresh files/changes back into the patch.

I feel like `stgit` currently lacks any easy way to achieve this.

This functionality closely mirrors what `git-delouse` script does:
[GitToolkit/GitDelouse](https://github.com/nvie/git-toolbelt#git-delouse)