### PR TITLE
Pass environment variables to Popen as dict of strings

### DIFF
--- a/stgit/run.py
+++ b/stgit/run.py
@@ -88,7 +88,8 @@ class Run:
         return [fsencode_utf8(c) for c in self._cmd]
 
     def _prep_env(self):
-        if self._env:
+        # Windows requires a dict of strings as env parameter, so don't encode for Windows
+        if self._env and os.name != 'nt':
             return {fsencode_utf8(k): fsencode_utf8(v) for k, v in self._env.items()}
         else:
             return self._env


### PR DESCRIPTION
In Python 3, the env argument to Popen has to be a dict of strings, see
https://bugzilla.mozilla.org/show_bug.cgi?id=1585258#c4
This is important when running under Windows, where the unicode strings
are processed directly by the subprocess C code.

However, under posix systems the environment variables are serialized to
bytes using the file system encoding, which may not support unicode
characters.
This means that passing bytes as environment variables and skipping the
encoding is mandatory on posix in order to support unicode environment
variables.

Therefore skip encoding when on Windows.

Fixes: #79 