### PR TITLE
bug(#85): fix refresh crashes when index contains added files and path limiting

### DIFF
--- a/stgit/lib/git/iw.py
+++ b/stgit/lib/git/iw.py
@@ -332,9 +332,9 @@ class IndexAndWorktree:
     def update_index(self, paths):
         """Update the index with files from the worktree. C{paths} is an
         iterable of paths relative to the root of the repository."""
-        self.run(['git', 'update-index', '--remove', '-z', '--stdin']).input_nulterm(
-            paths
-        ).discard_output()
+        self.run(
+            ['git', 'update-index', '--remove', '--add', '-z', '--stdin']
+        ).input_nulterm(paths).discard_output()
 
     def worktree_clean(self):
         """Check whether the worktree is clean relative to index."""


### PR DESCRIPTION
CLOSES #85 

Adding `--add` to `git update-index` to make sure temporary index update does not crash when newly added files are present