### PR TITLE
stg series: add option to always show description

### DIFF
--- a/stgit/commands/series.py
+++ b/stgit/commands/series.py
@@ -84,6 +84,12 @@ options = [
         short='Show a short description for each patch',
     ),
     opt(
+        '--no-description',
+        action='store_false',
+        short='Inverse of --description',
+        dest='description',
+    ),
+    opt(
         '--author',
         action='store_true',
         short='Show the author name for each patch',

--- a/stgit/commands/series.py
+++ b/stgit/commands/series.py
@@ -196,6 +196,9 @@ def func(parser, options, args):
         cmp_stack = stack
         stack = directory.repository.get_stack(options.missing)
 
+    if options.description is None:
+        options.description = config.getbool('stgit.series.description')
+
     # current series patches
     applied = unapplied = hidden = ()
     if options.applied or options.unapplied or options.hidden:

--- a/stgit/config.py
+++ b/stgit/config.py
@@ -37,6 +37,7 @@ DEFAULTS = [
     ('stgit.pullcmd', ['git pull']),
     ('stgit.refreshsubmodules', ['no']),
     ('stgit.shortnr', ['5']),
+    ('stgit.series.description', ['no']),
     ('stgit.smtpdelay', ['5']),
     ('stgit.smtpserver', ['localhost:25']),
 ]

--- a/t/t0008-series.sh
+++ b/t/t0008-series.sh
@@ -90,6 +90,19 @@ test_expect_success 'Test description' '
     test_cmp expected.txt series.txt
 '
 
+test_expect_success 'Test description by default' '
+    git config stg.series.description yes &&
+    test_atexit "git config --unset stg.series.description" &&
+    stg series --description > series.txt 2> error.txt &&
+    test_line_count = 4 series.txt &&
+    test_line_count = 0 error.txt &&
+    echo "+ p0 # message 0" > expected.txt &&
+    echo "+ p1 # message 1" >> expected.txt &&
+    echo "> p2 # message 2" >> expected.txt &&
+    echo "- p3 # message 3" >> expected.txt &&
+    test_cmp expected.txt series.txt
+'
+
 test_expect_success 'Test empty' '
     stg series --empty > series.txt &&
     echo " + p0" > expected.txt &&

--- a/t/t0008-series.sh
+++ b/t/t0008-series.sh
@@ -103,6 +103,19 @@ test_expect_success 'Test description by default' '
     test_cmp expected.txt series.txt
 '
 
+test_expect_success 'Test --no-description' '
+    git config stg.series.description yes &&
+    test_atexit "git config --unset stg.series.description" &&
+    stg series --no-description > series.txt 2> error.txt &&
+    test_line_count = 4 series.txt &&
+    test_line_count = 0 error.txt &&
+    echo "+ p0" > expected.txt &&
+    echo "+ p1" >> expected.txt &&
+    echo "> p2" >> expected.txt &&
+    echo "- p3" >> expected.txt &&
+    test_cmp expected.txt series.txt
+'
+
 test_expect_success 'Test empty' '
     stg series --empty > series.txt &&
     echo " + p0" > expected.txt &&


### PR DESCRIPTION
Add a configuration parameter `stg.series.description` which, when set
to `yes` will always show the description in `stg series`.

With this enabled, users may pass `--no-description` to hide
descriptions in the output.

Resolves #88