### PR TITLE
Avoid warning message in default pull command

### DIFF
--- a/stgit/config.py
+++ b/stgit/config.py
@@ -34,7 +34,7 @@ DEFAULTS = [
     ('stgit.pager', ['less']),
     ('stgit.pick.expose-format', ['format:%B%n(imported from commit %H)']),
     ('stgit.pull-policy', ['pull']),
-    ('stgit.pullcmd', ['git pull']),
+    ('stgit.pullcmd', ['git pull --ff']),
     ('stgit.refreshsubmodules', ['no']),
     ('stgit.shortnr', ['5']),
     ('stgit.series.description', ['no']),


### PR DESCRIPTION
In newer versions of git, a warning message is printed unless one of the
following options is explicitly specified on the command line (or its
equivalent in the config): `--ff` `--no-ff` `--ff-only` `--rebase` `--no-rebase`

To avoid displaying this warning from the internals of git, pass the
`--ff` option in the default pull command.