### PR TITLE
refresh: Support --diff with --edit

### DIFF
--- a/stgit/commands/refresh.py
+++ b/stgit/commands/refresh.py
@@ -106,6 +106,12 @@ options = (
             short='Invoke an editor for the patch description',
         ),
         opt(
+            '-d',
+            '--diff',
+            action='store_true',
+            short='Edit the patch diff if -e was set',
+        ),
+        opt(
             '-a',
             '--annotate',
             metavar='NOTE',
@@ -380,6 +386,7 @@ def __refresh(
     include_submodules=False,
     no_verify=False,
     invoke_editor=False,
+    edit_diff=False,
 ):
     stack = directory.repository.current_stack
 
@@ -455,7 +462,7 @@ def __refresh(
         )
         if invoke_editor:
             cd, failed_diff = interactive_edit_patch(
-                stack.repository, cd, edit_diff=False, diff_flags=[]
+                stack.repository, cd, edit_diff=edit_diff, diff_flags=[]
             )
             assert not failed_diff
         if not no_verify and (invoke_editor or cd.message != orig_msg):
@@ -522,4 +529,5 @@ def func(parser, options, args):
             include_submodules=options.submodules,
             no_verify=options.no_verify,
             invoke_editor=options.edit,
+            edit_diff=options.diff,
         )

--- a/t/t7504-commit-msg-hook.sh
+++ b/t/t7504-commit-msg-hook.sh
@@ -317,4 +317,22 @@ test_expect_success "squash hook doesn't edit commit message (editor)" '
     commit_msg_is "more plus"
 '
 
+write_script diffedit <<EOF
+sed \
+    -e 's/old content/new content/' \
+    -e 's/old message/new message/' "\$1" > "\$1".tmp && mv "\$1".tmp "\$1"
+exit 0
+EOF
+test_expect_success "refresh hook edits message and diff (editor)" '
+    stg new -m "old message" p1 &&
+    echo "old content" > file &&
+    stg add file &&
+    stg refresh -i &&
+    GIT_EDITOR=./diffedit stg refresh -d -e &&
+    git log --pretty=format:%s%b -1 &&
+    commit_msg_is "new message" &&
+    test "$(grep "new content" file)" = "new content"
+'
+rm -f diffedit
+
 test_done


### PR DESCRIPTION
Add a `--diff` flag to `stg refresh` that, when used with `--edit`, is
equivalent to `stg edit --diff`.

Resolves #98

