### PR TITLE
Add support for core.hooksPath

### DIFF
--- a/stgit/utils.py
+++ b/stgit/utils.py
@@ -65,8 +65,19 @@ def call_editor(filename):
     out.done()
 
 
+def get_hooks_path(repository):
+    hooks_path = config.get('core.hookspath')
+    if hooks_path is None:
+        return os.path.join(repository.directory, 'hooks')
+    elif os.path.isabs(hooks_path) or repository.default_iw.cwd == os.curdir:
+        return hooks_path
+    else:
+        hooks_path = os.path.join(os.getcwd(), repository.default_iw.cwd, hooks_path)
+        return os.path.abspath(hooks_path)
+
+
 def get_hook(repository, hook_name, extra_env={}):
-    hook_path = os.path.join(repository.directory, 'hooks', hook_name)
+    hook_path = os.path.join(get_hooks_path(repository), hook_name)
     if not (os.path.isfile(hook_path) and os.access(hook_path, os.X_OK)):
         return None
 

--- a/t/t2703-refresh-pre-commit-hook.sh
+++ b/t/t2703-refresh-pre-commit-hook.sh
@@ -40,6 +40,15 @@ test_expect_success 'refresh with path limiting, succeeding hook' '
     stg refresh file
 '
 
+git config core.hooksPath .my-hooks
+mv $HOOKDIR .my-hooks
+test_expect_success 'refresh with core.hooksPath' '
+    echo "pre-commit-hook-path-limiting-success" >> file &&
+    stg refresh file
+'
+mv .my-hooks $HOOKDIR
+git config --unset core.hooksPath
+
 # now a hook that fails
 write_script "$HOOK" <<'EOF'
 exit 1


### PR DESCRIPTION
Git 2.9 made it easier to share hooks with the team by adding a `core.hooksPath` setting.
This change removes the hard-coded ".git/hooks" location (which is still the default though).

See also: https://git-scm.com/docs/git-config#Documentation/git-config.txt-corehooksPath