### PR TITLE
"stg mail": always include the first commit in the cover letter stats

### DIFF
--- a/stgit/commands/mail.py
+++ b/stgit/commands/mail.py
@@ -583,7 +583,7 @@ def __shortlog(stack, patches):
 
 
 def __diffstat(stack, patches):
-    tree1 = stack.patches[patches[0]].data.tree
+    tree1 = stack.patches[patches[0]].data.parent.data.tree
     tree2 = stack.patches[patches[-1]].data.tree
     return stack.repository.diff_tree(
         tree1,

--- a/t/t1900-mail.sh
+++ b/t/t1900-mail.sh
@@ -164,4 +164,19 @@ test_expect_success 'Edit cover' '
     grep     -e "Patch 4"
 '
 
+cat > cover.txt <<EOF
+From: A U Thor <author@example.com>
+Subject: Diffstat Cover Test
+
+A diffstat cover test.
+
+%(diffstat)s
+EOF
+test_expect_success 'Check cover letter diff stats' '
+    stg mail -m --cover=cover.txt $(stg top) > cover.mbox &&
+    t1=$(grep -m1 -A3 -F "foo.txt" cover.mbox) &&
+    t2=$(git diff --stat-width=72 --stat --summary HEAD~ HEAD) &&
+    test "$t1" = "$t2"
+'
+
 test_done


### PR DESCRIPTION
- Fixes the issue described here: https://github.com/stacked-git/stgit/issues/104 
- Adds a test case to avoid regressions