### PR TITLE
Add --interactive option to rebase

### DIFF
--- a/stgit/commands/common.py
+++ b/stgit/commands/common.py
@@ -322,6 +322,24 @@ def post_rebase(stack, applied, cmd_name, check_merged):
     return trans.run(iw)
 
 
+def delete_patches(stack, iw, patches):
+    def allow_conflicts(trans):
+        # Allow conflicts if the topmost patch stays the same.
+        if stack.patchorder.applied:
+            return trans.applied and trans.applied[-1] == stack.patchorder.applied[-1]
+        else:
+            return not trans.applied
+
+    trans = StackTransaction(stack, 'delete', allow_conflicts=allow_conflicts)
+    try:
+        to_push = trans.delete_patches(lambda pn: pn in patches)
+        for pn in to_push:
+            trans.push_patch(pn, iw)
+    except TransactionHalted:
+        pass
+    return trans.run(iw)
+
+
 #
 # Patch description/e-mail/diff parsing
 #

--- a/stgit/commands/delete.py
+++ b/stgit/commands/delete.py
@@ -1,6 +1,10 @@
 from stgit.argparse import opt, patch_range
-from stgit.commands.common import CmdException, DirectoryHasRepository, parse_patches
-from stgit.lib import transaction
+from stgit.commands.common import (
+    CmdException,
+    DirectoryHasRepository,
+    delete_patches,
+    parse_patches,
+)
 
 __copyright__ = """
 Copyright (C) 2005, Catalin Marinas <catalin.marinas@gmail.com>
@@ -78,20 +82,4 @@ def func(parser, options, args):
             parser.error('Can only spill topmost applied patches')
         iw = None  # don't touch index+worktree
 
-    def allow_conflicts(trans):
-        # Allow conflicts if the topmost patch stays the same.
-        if stack.patchorder.applied:
-            return trans.applied and trans.applied[-1] == stack.patchorder.applied[-1]
-        else:
-            return not trans.applied
-
-    trans = transaction.StackTransaction(
-        stack, 'delete', allow_conflicts=allow_conflicts
-    )
-    try:
-        to_push = trans.delete_patches(lambda pn: pn in patches)
-        for pn in to_push:
-            trans.push_patch(pn, iw)
-    except transaction.TransactionHalted:
-        pass
-    return trans.run(iw)
+    return delete_patches(stack, iw, patches)

--- a/stgit/commands/rebase.py
+++ b/stgit/commands/rebase.py
@@ -1,12 +1,22 @@
+import copy
+import itertools
+import re
+import typing
+from enum import Enum
+
+from stgit import utils
 from stgit.argparse import opt
 from stgit.commands.common import (
     CmdException,
     DirectoryGotoTopLevel,
+    delete_patches,
     git_commit,
     post_rebase,
     prepare_rebase,
     rebase,
 )
+from stgit.commands.squash import squash
+from stgit.utils import edit_string
 
 __copyright__ = """
 Copyright (C) 2005, Catalin Marinas <catalin.marinas@gmail.com>
@@ -26,10 +36,10 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 
 help = 'Move the stack base to another point in history'
 kind = 'stack'
-usage = ['[options] [--] <new-base-id>']
+usage = ['[options] [--] [new-base-id]']
 description = """
 Pop all patches from current stack, move the stack base to the given
-<new-base-id> and push the patches back.
+[new-base-id] and push the patches back.
 
 If you experience merge conflicts, resolve the problem and continue
 the rebase by executing the following sequence:
@@ -46,6 +56,12 @@ Or if you want to skip that patch:
 args = ['commit']
 options = [
     opt(
+        '-i',
+        '--interactive',
+        action='store_true',
+        short='Open an interactive editor to manipulate patches',
+    ),
+    opt(
         '-n',
         '--nopush',
         action='store_true',
@@ -61,11 +77,158 @@ options = [
 
 directory = DirectoryGotoTopLevel()
 
+INTERACTIVE_APPLY_LINE = '# --- APPLY_LINE ---'
+
+INTERACTIVE_HELP_INSTRUCTIONS = """
+# Commands:
+# k, keep <patch> = do not modify this patch
+# s, squash <patch> = squash patch into the previous patch
+# d, delete <patch> = delete patch
+#
+# These lines can be re-ordered; they are executed from top to bottom.
+#
+# Patches above the APPLY_LINE are applied; other patches are kept unapplied.
+"""
+
+
+def __get_description(stack, patch):
+    """Extract and return a patch's short description"""
+    cd = stack.patches[patch].data
+    return cd.message_str.strip().split('\n', 1)[0].rstrip()
+
+
+class Action(Enum):
+    # do nothing; a 'no-op'
+    KEEP = 0
+    # delete the patch
+    DELETE = 1
+    # squash the patch into the previous patch
+    SQUASH = 2
+
+
+Instruction = typing.NamedTuple(
+    'Instruction', [('patch_name', str), ('action', Action), ('apply', bool)]
+)
+
+
+def __do_rebase_interactive(repository, previously_applied_patches, check_merged):
+    """Opens an interactive editor, generates instruction list, and executes instructions."""
+    stack = repository.get_stack()
+
+    if len(stack.patchorder.all) == 0:
+        return utils.STGIT_SUCCESS
+
+    name_len = max((len(s) for s in stack.patchorder.all))
+    line = 'keep {{:<{name_len}}} # {{}}'.format(name_len=name_len)
+
+    # create a list of all patches to send to the editor
+    instructions = []
+    for pn in previously_applied_patches:
+        patch = (pn, __get_description(stack, pn))
+        instructions.append(line.format(*patch))
+    instructions.append(INTERACTIVE_APPLY_LINE)
+    for pn in stack.patchorder.all:
+        if pn in previously_applied_patches:
+            continue
+        patch = (pn, __get_description(stack, pn))
+        instructions.append(line.format(*patch))
+    instructions.append(INTERACTIVE_HELP_INSTRUCTIONS)
+
+    # open an editor to let the user generate the 'todo' instructions
+    todo = edit_string(
+        '\n'.join(instructions),
+        '.stgit-rebase-interactive.txt',
+    )
+
+    # parse the instructions we've been given
+    seen_apply_line = False
+    instructions = []
+    for line in todo.splitlines():
+        line = line.strip()
+
+        # record when we find the APPLY_LINE so we know which patches to apply
+        if INTERACTIVE_APPLY_LINE in line:
+            if INTERACTIVE_APPLY_LINE == line:
+                seen_apply_line = True
+            else:
+                raise CmdException("Bad APPLY_LINE: '%s'" % line)
+
+        # ignore comment lines
+        if not line or line.startswith('#'):
+            continue
+
+        # parse a single instruction
+        match = re.match(r'(\S+) (\S+).*', line)
+        if not match:
+            raise CmdException("Bad todo line: '%s'" % line)
+        instruction_str, patch_name = match.groups()
+        if patch_name not in stack.patchorder.all:
+            raise CmdException("Bad patch name '%s'" % patch_name)
+        if instruction_str in ('k', 'keep'):
+            instruction_type = Action.KEEP
+        elif instruction_str in ('d', 'delete'):
+            instruction_type = Action.DELETE
+        elif instruction_str in ('s', 'squash'):
+            instruction_type = Action.SQUASH
+        else:
+            raise CmdException("Unknown instruction '%s'" % instruction_str)
+
+        # save the instruction to execute later
+        instructions.append(
+            Instruction(patch_name, instruction_type, not seen_apply_line)
+        )
+
+    # execute all the non-squash instructions first. we use a copy to make sure
+    # we don't skip any instructions as we delete from the list
+    for instruction in copy.copy(instructions):
+        if instruction.apply:
+            post_rebase(stack, {instruction.patch_name}, 'rebase', check_merged)
+        if instruction.action == Action.DELETE:
+            delete_patches(stack, stack.repository.default_iw, {instruction.patch_name})
+            instructions.remove(instruction)
+
+    # execute squashes last because patch names may change during squashes. this
+    # is a double loop so we can handle multiple chains of multiple squashes
+    for index in itertools.count():
+        if index >= len(instructions):
+            break  # reached the end of the instruction list
+        # determine how many of the next N instructions are squashes
+        squashes_found = False
+        for num_squashes in itertools.count(1):
+            if len(instructions) <= index + num_squashes:
+                break  # reached the end of the instruction list
+            if instructions[index + num_squashes].action == Action.SQUASH:
+                squashes_found = True
+            else:
+                break  # not a squash; chain is over
+        # execute squash
+        if squashes_found:
+            squashes = instructions[index : index + num_squashes]
+            squash(
+                stack,
+                stack.repository.default_iw,
+                None,
+                None,
+                None,
+                [p.patch_name for p in squashes],
+            )
+            # remove the squashed patches from the instruction set
+            instructions = (
+                instructions[: index + 1] + instructions[index + num_squashes :]
+            )
+    return utils.STGIT_SUCCESS
+
 
 def func(parser, options, args):
     """Rebase the current stack"""
-    if len(args) != 1:
-        parser.error('incorrect number of arguments')
+
+    if options.interactive:
+        # destination is optional for '--interactive'
+        if len(args) not in (0, 1):
+            parser.error('incorrect number of arguments')
+    else:
+        if len(args) != 1:
+            parser.error('incorrect number of arguments')
 
     repository = directory.repository
     stack = repository.get_stack()
@@ -74,14 +237,18 @@ def func(parser, options, args):
     if stack.protected:
         raise CmdException('This branch is protected. Rebase is not permitted')
 
-    target = git_commit(args[0], repository)
+    if len(args) > 0:
+        target = git_commit(args[0], repository)
+    else:
+        target = stack.base
 
     applied = stack.patchorder.applied
-
     retval = prepare_rebase(stack, 'rebase')
     if retval:
         return retval
-
     rebase(stack, iw, target)
-    if not options.nopush:
+
+    if options.interactive:
+        return __do_rebase_interactive(repository, applied, check_merged=options.merged)
+    elif not options.nopush:
         return post_rebase(stack, applied, 'rebase', check_merged=options.merged)

--- a/stgit/commands/squash.py
+++ b/stgit/commands/squash.py
@@ -106,7 +106,7 @@ def _squash_patches(trans, patches, msg, save_template, no_verify=False):
     return cd
 
 
-def _squash(stack, iw, name, msg, save_template, patches, no_verify=False):
+def squash(stack, iw, name, msg, save_template, patches, no_verify=False):
     # If a name was supplied on the command line, make sure it's OK.
     if name and name not in patches and name in stack.patches:
         raise CmdException('Patch name "%s" already taken' % name)
@@ -162,7 +162,7 @@ def func(parser, options, args):
         raise CmdException('Need at least two patches')
     if options.name and not stack.patches.is_name_valid(options.name):
         raise CmdException('Patch name "%s" is invalid' % options.name)
-    return _squash(
+    return squash(
         stack,
         stack.repository.default_iw,
         options.name,

--- a/t/t2203-rebase-interactive.sh
+++ b/t/t2203-rebase-interactive.sh
@@ -1,0 +1,191 @@
+#!/bin/sh
+
+test_description='test rebase --interactive'
+
+. ./test-lib.sh
+
+
+test_expect_success 'Initialize StGit stack' '
+    stg init &&
+    stg new p0 -m p0 &&
+    stg new p1 -m p1 &&
+    stg new p2 -m p2 &&
+    stg new p3 -m p3
+'
+
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\EOF
+	echo "keep p0\nkeep p1\n# --- APPLY_LINE ---\nkeep p2\nkeep p3" >"$1"
+	EOF
+'
+test_expect_success 'Apply patches with APPLY_LINE' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    stg rebase --interactive &&
+    test "$(stg series --applied -c)" = "2" &&
+    git diff-index --quiet HEAD
+'
+
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\EOF
+	echo "# --- APPLY_LINE ---this_text_does_not_belong" >"$1"
+	EOF
+'
+test_expect_success 'Bad APPLY_LINE throws an error' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    command_error stg rebase --interactive 2>&1 |
+    grep -e "Bad APPLY_LINE"
+'
+
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\EOF
+	echo "keep p0\nkeep p1" >"$1"
+	EOF
+'
+test_expect_success 'Apply patches without APPLY_LINE' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    stg rebase --interactive &&
+    test "$(stg series --applied -c)" = "2" &&
+    git diff-index --quiet HEAD
+'
+
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\EOF
+	echo "keep" >"$1"
+	EOF
+'
+test_expect_success 'Bad todo line throws error' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    command_error stg rebase --interactive 2>&1 |
+    grep -e "Bad todo line"
+'
+
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\EOF
+	echo "keep invalid_patch_name" >"$1"
+	EOF
+'
+test_expect_success 'Bad patch name throws error' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    command_error stg rebase --interactive 2>&1 |
+    grep -e "Bad patch name"
+'
+
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\EOF
+	echo "invalid_instruction p1" >"$1"
+	EOF
+'
+test_expect_success 'Bad instruction throws error' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    command_error stg rebase --interactive 2>&1 |
+    grep -e "Unknown instruction"
+'
+
+test_expect_success 'Setup stgit stack' '
+    stg new p4 -m p4
+'
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\eof
+	echo "delete p4" >"$1"
+	eof
+'
+test_expect_success 'Delete a patch' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    stg rebase --interactive &&
+    test "$(stg series -c)" = "4" &&
+    git diff-index --quiet HEAD
+'
+
+test_expect_success 'Setup stgit stack' '
+    stg delete $(stg series --all --noprefix --no-description) &&
+    stg new -m p0 &&
+    stg new -m p1 &&
+    stg new -m p2 &&
+    stg new -m p3
+'
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\eof
+	echo "delete p0\ndelete p2" >"$1"
+	eof
+'
+test_expect_success 'Delete two patches and the correct two are deleted' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    stg rebase --interactive &&
+    test "$(echo $(stg series --noprefix))" = "p1 p3" &&
+    git diff-index --quiet HEAD
+'
+
+test_expect_success 'Setup stgit stack' '
+    stg delete $(stg series --all --noprefix --no-description) &&
+    stg new -m p0 &&
+    stg new -m p1
+'
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\EOF
+	echo "keep p0\nsquash p1" >"$1"
+	EOF
+'
+test_expect_success 'Squash succeeds' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    stg rebase --interactive &&
+    git diff-index --quiet HEAD &&
+    test "$(stg series -c)" = "1"
+'
+
+test_expect_success 'Setup stgit stack' '
+    stg delete $(stg series --all --noprefix --no-description) &&
+    stg new -m p0 &&
+    stg new -m p1 &&
+    stg new -m p2
+'
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\EOF
+	echo "keep p0\nsquash p1\nsquash p2" >"$1"
+	EOF
+'
+test_expect_success 'Squash on a Squash succeeds' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    stg rebase --interactive &&
+    git diff-index --quiet HEAD &&
+    test "$(stg series -c)" = "1"
+'
+
+test_expect_success 'Setup stgit stack' '
+    stg delete $(stg series --all --noprefix --no-description) &&
+    stg new -m p0 &&
+    stg new -m p1 &&
+    stg new -m p2 &&
+    stg new -m p3 &&
+    stg new -m p4 &&
+    stg new -m p5
+'
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\EOF
+	echo "keep p0\nsquash p1\nsquash p2\nkeep p3\nsquash p4\nkeep p5" >"$1"
+	EOF
+'
+test_expect_success 'Two independent squash chains succeed' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    stg rebase --interactive &&
+    git diff-index --quiet HEAD &&
+    test "$(stg series -c)" = "3"
+'
+
+test_expect_success 'No patches exits early' '
+    stg delete $(stg series --all --noprefix --no-description) &&
+    stg rebase --interactive
+'
+
+
+test_done


### PR DESCRIPTION
`stg rebase --interactive` is a new tool which mirrors `git rebase --interactive`.

Using an editor `--interactive` lets the user reorder patches, squash patch chains, or delete individual patches.

[![asciicast](https://asciinema.org/a/BWJZZ65vFtlpGubobNLbixr9G.svg)](https://asciinema.org/a/BWJZZ65vFtlpGubobNLbixr9G)

Further instructions could be added but this seemed like a good base set. I've been using this locally and it helps execute certain sets of commands much faster! Tests are included.