### PR TITLE
Ensure a newline after each commit in 'stg squash'.

### DIFF
--- a/stgit/commands/squash.py
+++ b/stgit/commands/squash.py
@@ -1,3 +1,4 @@
+# TODO (not this file): add 'verbose=1' support to 'stg new', similar to 'git commit'
 from stgit import argparse, utils
 from stgit.argparse import opt, patch_range
 from stgit.commands.common import (
@@ -86,7 +87,7 @@ def _squash_patches(trans, patches, msg, save_template, no_verify=False):
                 pn,
                 num,
             )
-            msg += "\n%s\n" % trans.patches[pn].data.message_str
+            msg += "\n%s\n\n" % trans.patches[pn].data.message_str.strip()
         msg += (
             "# Please enter the commit message for your patch. Lines starting\n"
             "# with '#' will be ignored."

--- a/stgit/commands/squash.py
+++ b/stgit/commands/squash.py
@@ -1,4 +1,3 @@
-# TODO (not this file): add 'verbose=1' support to 'stg new', similar to 'git commit'
 from stgit import argparse, utils
 from stgit.argparse import opt, patch_range
 from stgit.commands.common import (
@@ -87,7 +86,7 @@ def _squash_patches(trans, patches, msg, save_template, no_verify=False):
                 pn,
                 num,
             )
-            msg += "\n%s\n\n" % trans.patches[pn].data.message_str.strip()
+            msg += "\n%s\n\n" % trans.patches[pn].data.message_str.rstrip()
         msg += (
             "# Please enter the commit message for your patch. Lines starting\n"
             "# with '#' will be ignored."


### PR DESCRIPTION
I observed an issue locally where if a commit message does not include a
trailing newline, the suggested commit message is more "scrunched" than
we'd like it to be -- there's no newline between the commit message and the
instructions.

![squash message](https://user-images.githubusercontent.com/206988/123317697-4cc8b080-d4fc-11eb-8dc2-868f15b8ed34.png)


This scenario is easy to get into if you perform a squash followed by
another squash onto the same patch (by default the trailing newline is 
stripped).

The fix here is to strip all newlines from the end of each commit
message and then add two newlines to the end (one to get to the next
line, another to ensure the blank line between messages).