### PR TITLE
Reorder squash message to ease readibility.

### DIFF
--- a/stgit/commands/squash.py
+++ b/stgit/commands/squash.py
@@ -82,9 +82,9 @@ def _squash_patches(trans, patches, msg, save_template, no_verify=False):
     if msg is None:
         msg = "# This is a combination of %s patches.\n" % len(patches)
         for num, pn in enumerate(patches, 1):
-            msg += "# This is the commit message for %s (patch #%s):" % (
-                pn,
+            msg += "# This is the commit message for patch #%s (%s):" % (
                 num,
+                pn,
             )
             msg += "\n%s\n" % trans.patches[pn].data.message_str
         msg += (


### PR DESCRIPTION
After using this in practice, I think that having the patch number
followed by the patch name is more readable. With this change it's
easier to scan the commit message to determine where each change
ends and the next one begins.

Before:
![before](https://user-images.githubusercontent.com/206988/123318815-a1b8f680-d4fd-11eb-965c-2d745c04f823.png)

After:
![image](https://user-images.githubusercontent.com/206988/123318793-9c5bac00-d4fd-11eb-9c15-c6912322e523.png)

I recognize that this PR is more personal preference; it's not the end
of the world if we leave it as-is.