### PR TITLE
Empty 'squash' commit message aborts the squash.

### DIFF
--- a/stgit/commands/squash.py
+++ b/stgit/commands/squash.py
@@ -100,7 +100,11 @@ def _squash_patches(trans, patches, name, msg, save_template, no_verify=False):
             raise SaveTemplateDone()
         else:
             msg = utils.edit_string(msg, '.stgit-squash.txt')
+
     msg = '\n'.join(_strip_comments(msg)).strip()
+    if not msg:
+        raise CmdException('Aborting squash due to empty commit message')
+
     cd = cd.set_message(msg)
 
     if not no_verify:

--- a/t/t2600-squash.sh
+++ b/t/t2600-squash.sh
@@ -50,6 +50,19 @@ test_expect_success 'Squash at stack top' '
     [ "$(echo $(stg series --unapplied --noprefix))" = "" ]
 '
 
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\eof
+	echo "" >"$1"
+	eof
+'
+test_expect_success 'Empty commit message aborts the squash' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    command_error stg squash --name=p0 p0 q1 2>&1 |
+    grep -e "Aborting squash due to empty commit message" &&
+    test "$(echo $(stg series))" = "+ p0 > q1"
+'
+
 cat > editor <<EOF
 #!/bin/sh
 echo "Editor was invoked" | tee editor-invoked


### PR DESCRIPTION
This mirrors the behavior seen by Git. In git, if you exit the commit 
message editor without providing any message, the squash is aborted:

[![asciicast](https://asciinema.org/a/6T0n15zn2mVdzttSIEzttwCbO.svg)](https://asciinema.org/a/6T0n15zn2mVdzttSIEzttwCbO)

This PR brings the same functionality to stgit:

[![asciicast](https://asciinema.org/a/422492.svg)](https://asciinema.org/a/422492)

Message text:
```
$ stg squash foo bar                                                                                                                                                                                                 
Invoking the editor: "vim .stgit-squash.txt" ... done                                                                                                                                                                
stg squash: Aborting squash due to empty commit message  
```