### PR TITLE
Add --verbose option to 'stg new'

### DIFF
--- a/t/t1003-new.sh
+++ b/t/t1003-new.sh
@@ -87,6 +87,21 @@ test_expect_success \
     stg show | grep "Patch Description Template"
 '
 
+test_expect_success \
+    'New with verbose flag' '
+    echo "Patch Description Template" > .git/patchdescr.tmpl &&
+    stg new --verbose verbose-flag-patch &&
+    stg show | grep "Patch Description Template"
+'
+
+test_expect_success \
+    'New with verbose config option' '
+    test_config commit.verbose "1" &&
+    echo "Patch Description Template" > .git/patchdescr.tmpl &&
+    stg new --verbose verbose-config-patch &&
+    stg show | grep "Patch Description Template"
+'
+
 test_expect_failure \
     'Patch with slash in name' '
     stg new bar/foo -m "patch bar/foo"

--- a/t/t1800-import.sh
+++ b/t/t1800-import.sh
@@ -14,7 +14,7 @@ test_expect_success \
 
 test_expect_success 'setup fake editor' '
 	write_script fake-editor <<-\EOF
-	echo "fake edit" >>"$1"
+	echo "fake edit" >"$1"
 	EOF
 '
 


### PR DESCRIPTION
Git has a great feature where you can get a 'git diff' in the editor window when
creating a commit. This can help give context while you write your commit
message.

This PR adds this functionality to 'stg new'. Just like Git, there's two ways to
trigger the new feature:
1. `stg new --verbose`
2. Setting the config setting `commit.verbose=1` (borrows Git's config var)

[![asciicast](https://asciinema.org/a/422507.svg)](https://asciinema.org/a/422507)