### PR TITLE
Add --autostash to 'stg rebase'

### DIFF
--- a/examples/gitconfig
+++ b/examples/gitconfig
@@ -85,6 +85,9 @@
 	# Behave as if the --keep option is always passed
 	#autokeep = no
 
+	# Behave as if the --autostash option is always passed to rebase
+	#autostash = no
+
 	# Include submodules by default when refreshing patch contents.
 	#refreshsubmodules = no
 

--- a/stgit/commands/rebase.py
+++ b/stgit/commands/rebase.py
@@ -16,6 +16,8 @@ from stgit.commands.common import (
     rebase,
 )
 from stgit.commands.squash import squash
+from stgit.config import config
+from stgit.run import RunException
 from stgit.utils import edit_string
 
 __copyright__ = """
@@ -73,6 +75,18 @@ options = [
         action='store_true',
         short='Check for patches merged upstream',
     ),
+    opt(
+        '--autostash',
+        action='store_true',
+        short='Stash changes before the rebase and apply them after',
+        default=config.getbool('stgit.autostash'),
+        long='''
+    Automatically create a temporary stash before the operation begins, and
+    apply it after the operation ends. This means that you can run rebase on a
+    dirty work-tree. However, use with care: the final stash application after a
+    successful rebase might result in non-trivial conflicts.
+    ''',
+    ),
 ]
 
 directory = DirectoryGotoTopLevel()
@@ -89,6 +103,16 @@ INTERACTIVE_HELP_INSTRUCTIONS = """
 #
 # Patches above the APPLY_LINE are applied; other patches are kept unapplied.
 """
+
+
+class StashPopConflictException(RunException):
+    """Exception raised there's a conflict when popping the stash after --autostash"""
+
+    def __init__(self):
+        super().__init__(
+            'Merge conflict raised when popping stash after rebase. Resolve the '
+            'conflict, then delete the stash with `git stash drop`.'
+        )
 
 
 def __get_description(stack, patch):
@@ -242,6 +266,12 @@ def func(parser, options, args):
     else:
         target = stack.base
 
+    if options.autostash and not iw.worktree_clean():
+        repository.run(['git', 'stash', 'push']).run()
+        stashed_worktree = True
+    else:
+        stashed_worktree = False
+
     applied = stack.patchorder.applied
     retval = prepare_rebase(stack, 'rebase')
     if retval:
@@ -249,6 +279,18 @@ def func(parser, options, args):
     rebase(stack, iw, target)
 
     if options.interactive:
-        return __do_rebase_interactive(repository, applied, check_merged=options.merged)
+        retval = __do_rebase_interactive(
+            repository, applied, check_merged=options.merged
+        )
     elif not options.nopush:
-        return post_rebase(stack, applied, 'rebase', check_merged=options.merged)
+        retval = post_rebase(stack, applied, 'rebase', check_merged=options.merged)
+    else:
+        retval = None
+
+    if stashed_worktree:
+        try:
+            repository.run(['git', 'stash', 'pop']).run()
+        except RunException:
+            raise StashPopConflictException()
+
+    return retval

--- a/t/t2204-rebase-autostash.sh
+++ b/t/t2204-rebase-autostash.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+test_description='test rebase --autostash'
+
+. ./test-lib.sh
+
+test_expect_success \
+	'Setup a multi-commit branch and fork an stgit stack' \
+	'
+	echo foo > file1 &&
+	stg add file1 &&
+	git commit -m a &&
+	echo foo > file2 &&
+	stg add file2 &&
+	git commit -m b &&
+
+	stg branch --create stack &&
+	stg new p -m . &&
+	git notes add -m note &&
+	echo bar >> file1 &&
+	stg refresh
+	'
+
+test_expect_success 'dirty workdir aborts rebase' \
+	'
+	echo foo >> file1 &&
+	command_error stg rebase master 2>&1 |
+	grep -e "Worktree not clean."
+	'
+
+test_expect_success 'dirty workdir works with --autostash' \
+	'
+	stg rebase master --autostash &&
+	test $(stg series --applied -c) = 1 &&
+	git diff-index HEAD 2>&1 | 
+	grep -e file1
+	'
+
+test_expect_success \
+	'dirty workdir works with stgit.autostash config' \
+	'
+	test_config stgit.autostash "yes" &&
+	stg rebase master~1 &&
+	test $(stg series --applied -c) = 1 &&
+	git diff-index HEAD 2>&1 | 
+	grep -e file1
+	'
+
+test_expect_success \
+	'Setup fake editor' '
+	write_script fake-editor <<-\EOF
+	echo "" >"$1"
+	EOF
+'
+test_expect_success \
+	'rebase --autostash throws helpful error message in conflict' \
+	'
+	test_set_editor "$(pwd)/fake-editor" &&
+	test_when_finished test_set_editor false &&
+	git checkout --force &&
+	stg rebase master
+	echo baz > file2 &&
+	command_error stg rebase master~1 --interactive --autostash 2>&1 |
+	grep -e "Merge conflict raised when popping stash after rebase"
+	'
+
+test_done


### PR DESCRIPTION
This mirrors a feature of 'git rebase' where, instead of erroring on a dirty
worktree, `--autostash` will stash the changes and apply them after the rebase
has completed.

I'm not sure if it's more 'stgit-ish' to create a patch or a stash. I kept the
git behavior (a stash) but I could see arguments either way.

[![asciicast](https://asciinema.org/a/423971.svg)](https://asciinema.org/a/423971)