### PR TITLE
Update squash instructions to include empty messages.

### DIFF
--- a/stgit/commands/squash.py
+++ b/stgit/commands/squash.py
@@ -92,7 +92,7 @@ def _squash_patches(trans, patches, name, msg, save_template, no_verify=False):
             msg += "\n%s\n\n" % trans.patches[pn].data.message_str.rstrip()
         msg += (
             "# Please enter the commit message for your patch. Lines starting\n"
-            "# with '#' will be ignored."
+            "# with '#' will be ignored, and an empty message aborts the commit."
         )
 
         if save_template:


### PR DESCRIPTION
This matches the behavior of git (in behavior and in instruction text). This
change should have been part of https://github.com/stacked-git/stgit/pull/121
but was overlooked.

[![asciicast](https://asciinema.org/a/423856.svg)](https://asciinema.org/a/423856)