### PR TITLE
Resolve 'flake8' errors.

### DIFF
--- a/stgit/commands/__init__.py
+++ b/stgit/commands/__init__.py
@@ -87,7 +87,7 @@ def py_commands(commands, f):
 
 def _command_list(commands):
     kinds = {}
-    for cmd, mod, kind, help in commands:
+    for cmd, _, kind, help in commands:
         kinds.setdefault(kind, {})[cmd] = help
     for kind in _kind_order:
         kind = _kinds[kind]

--- a/stgit/commands/mail.py
+++ b/stgit/commands/mail.py
@@ -464,7 +464,7 @@ def __update_header(msg, header, addr='', ignore=()):
     return set(addr for _, addr in addr_pairs)
 
 
-def __build_address_headers(msg, options, extra_cc=[]):
+def __build_address_headers(msg, options, extra_cc):
     """Build the address headers and check existing headers in the
     template.
     """

--- a/stgit/commands/uncommit.py
+++ b/stgit/commands/uncommit.py
@@ -120,7 +120,7 @@ def func(parser, options, args):
     next_commit = stack.base
     if patch_nr:
         out.start('Uncommitting %d patches' % patch_nr)
-        for i in range(patch_nr):
+        for _ in range(patch_nr):
             check_and_append(commits, next_commit)
             next_commit = next_commit.data.parent
     else:

--- a/stgit/utils.py
+++ b/stgit/utils.py
@@ -75,7 +75,9 @@ def get_hooks_path(repository):
         return os.path.join(repository.default_worktree.directory, hooks_path)
 
 
-def get_hook(repository, hook_name, extra_env={}):
+def get_hook(repository, hook_name, extra_env=None):
+    if not extra_env:
+        extra_env = {}
     hook_path = os.path.join(get_hooks_path(repository), hook_name)
     if not (os.path.isfile(hook_path) and os.access(hook_path, os.X_OK)):
         return None


### PR DESCRIPTION
Seeing these errors when running flake8 locally:

```
make lint-flake8
./stgit/utils.py:78:47: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
./stgit/commands/mail.py:467:52: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
./stgit/commands/uncommit.py:123:13: B007 Loop control variable 'i' not used within the loop body. If this is intended, start the name with an underscore.
./stgit/commands/__init__.py:90:14: B007 Loop control variable 'mod' not used within the loop body. If this is intended, start the name with an underscore.
```

It's not clear to me why the CI isn't failing with the same errors.