### PR TITLE
Fix 'prove' error with bang line.

### DIFF
--- a/t/t1009-gpg.sh
+++ b/t/t1009-gpg.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 test_description='Test gpg signatures'
 
 . ./test-lib.sh


### PR DESCRIPTION
I'm seeing this error locally:

```
$ prove --timer --jobs 15 ./t[0-9]*.sh

[23:13:23] ./t1002-branch-clone.sh ............. ok     3226 ms ( 0.03 usr  0.01 sys +  6.42 cusr  1.90 csys =  8.36 CPU)
===(      87;4  5/?  8/?  0/?  0/?  5/?  6/?  9/?  7/?  0/?  8/?... )===String found where operator expected at ./t1009-gpg.sh line 3, near "echo ""
        (Missing semicolon on previous line?)
Bareword found where operator expected at ./t1009-gpg.sh line 3, near "$(echo"
        (Missing operator before echo?)
Bareword found where operator expected at ./t1009-gpg.sh line 3, near "$(stg"
        (Missing operator before stg?)
String found where operator expected at ./t1009-gpg.sh line 3, near ")" = ""
        (Missing operator before " = "?)
Bareword found where operator expected at ./t1009-gpg.sh line 3, near "" = "p2"
        (Missing operator before p2?)
String found where operator expected at ./t1009-gpg.sh line 3, near "echo ""
        (Missing semicolon on previous line?)
Bareword found where operator expected at ./t1009-gpg.sh line 3, near "$(stg"
        (Missing operator before stg?)
String found where operator expected at ./t1009-gpg.sh line 3, near ")" = ""
        (Missing operator before " = "?)
Bareword found where operator expected at ./t1009-gpg.sh line 3, near "" = "p1"
        (Missing operator before p1?)
String found where operator expected at ./t1009-gpg.sh line 3, at end of line
        (Missing semicolon on previous line?)
syntax error at ./t1009-gpg.sh line 3, near ". ."
Unknown regexp modifier "/b" at ./t1009-gpg.sh line 3, at end of line
Can't find string terminator '"' anywhere before EOF at ./t1009-gpg.sh line 3.
[23:13:23] ./t1009-gpg.sh ...................... Dubious, test returned 255 (wstat 65280, 0xff00)
No subtests run
```

The error is resolved when I add a shebang line to the gpg test.