### PR TITLE
Add .cov-files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ ChangeLog
 .tox
 htmlcov/
 .coverage
+.cov-files/
 .DS_Store


### PR DESCRIPTION
This directory appears when one runs `make coverage`. It should be ignored.