### PR TITLE
Add 'edit' instruction to 'rebase --interactive'.

### DIFF
--- a/t/t2203-rebase-interactive.sh
+++ b/t/t2203-rebase-interactive.sh
@@ -104,6 +104,22 @@ test_expect_success 'Delete a patch' '
 '
 
 test_expect_success 'Setup stgit stack' '
+    stg new p4 -m p4
+'
+test_expect_success 'Setup fake editor' '
+	write_script fake-editor <<-\eof
+	echo "edit p4" >"$1"
+	eof
+'
+test_expect_success 'Edit a patch' '
+    test_set_editor "$(pwd)/fake-editor" &&
+    test_when_finished test_set_editor false &&
+    stg rebase --interactive &&
+    git diff-index --quiet HEAD &&
+    stg show | grep -e "edit p4"
+'
+
+test_expect_success 'Setup stgit stack' '
     stg delete $(stg series --all --noprefix --no-description) &&
     stg new -m p0 &&
     stg new -m p1 &&

--- a/t/t3300-edit.sh
+++ b/t/t3300-edit.sh
@@ -182,6 +182,18 @@ test_expect_success 'Edit patch diff' '
 '
 rm -f diffedit
 
+write_script diffedit <<EOF
+sed 's/+1,4/+1,5/' "\$1" > "\$1".tmp && mv "\$1".tmp "\$1"
+EOF
+test_expect_success 'Edit patch diff which fails to apply' '
+    EDITOR=./diffedit stg edit -d p2 2>&1 |
+    grep -e "Edited patch did not apply." &&
+    test "$(grep 111 foo)" = "111YY" &&
+    test_file_not_empty .stgit-failed.patch
+'
+rm -f diffedit
+rm -f .stgit-failed.patch
+
 test_expect_success 'Sign a patch' '
     m=$(msg HEAD) &&
     stg edit --sign p2 &&

--- a/t/t7504-commit-msg-hook.sh
+++ b/t/t7504-commit-msg-hook.sh
@@ -123,6 +123,11 @@ test_expect_success 'edit with failing hook' '
     command_error stg edit -m "another"
 '
 
+test_expect_success 'edit --diff with failing hook' '
+    command_error stg edit --diff -m "another" 2>&1 |
+    grep -e "The commit-msg hook failed"
+'
+
 test_expect_success 'refresh with failing hook' '
     command_error stg refresh -m "another" &&
     stg delete refresh-temp


### PR DESCRIPTION
Add 'edit' instruction to 'rebase --interactive'.

'edit' opens the interactive editor to modify the commit.

I feel safer making these changes after the test additions included in
https://github.com/stacked-git/stgit/pull/132; this PR has been tested against
those new tests. I can't figure out how to base this PR off of that PR, so that 
PR's changes are currently included in this PR as well.