### PR TITLE
Tell 'coverage' that our loops have exits.

### DIFF
--- a/stgit/commands/rebase.py
+++ b/stgit/commands/rebase.py
@@ -138,7 +138,7 @@ def __perform_squashes(instructions, index, stack):
     """Perform any consecutive squashes from 'index' onwards."""
     squashes_found = False
     # loop to determine how many of the next N instructions are squashes
-    for num_squashes in itertools.count(1):
+    for num_squashes in itertools.count(1):  # pragma: no branch
         if len(instructions) <= index + num_squashes:
             break  # reached the end of the instruction list
         if instructions[index + num_squashes].action == Action.SQUASH:
@@ -232,7 +232,7 @@ def __do_rebase_interactive(repository, previously_applied_patches, check_merged
             Instruction(patch_name, instruction_type, not seen_apply_line)
         )
 
-    for index in itertools.count():
+    for index in itertools.count():  # pragma: no branch
         if index >= len(instructions):
             break  # reached the end of the instruction list
         if instructions[index].action == Action.DELETE:


### PR DESCRIPTION
By default, 'coverage' can not tell that our "infinite" loops complete.

![image](https://user-images.githubusercontent.com/206988/124956085-a1345b80-dfe5-11eb-8299-63cfefe3738b.png)

Let it know that it doesn't have to worry about branch coverage for these
loops; they are always eventually exhausted.

This follows the instructions from 
https://coverage.readthedocs.io/en/coverage-5.0/branch.html#structurally-partial-branches