### PR TITLE
Use correct 'diff' command in 'stg new'.

### DIFF
--- a/stgit/commands/common.py
+++ b/stgit/commands/common.py
@@ -476,14 +476,12 @@ def _git_status():
     return [line for line in out if '(use' not in line]
 
 
-def _git_diff():
-    return Run('git', 'diff').output_lines()
-
-
 def update_commit_data(
-    cd, message=None, author=None, sign_str=None, edit=False, verbose=False
+    repo, cd, message=None, author=None, sign_str=None, edit=False, verbose=False
 ):
     """Create updated CommitData according to the command line options."""
+    iw = repo.default_iw
+
     # Set the commit message from commandline.
     if message is not None:
         cd = cd.set_message(message)
@@ -513,7 +511,7 @@ def update_commit_data(
             message_str += (
                 COMMIT_MESSAGE_DEMARCATION_LINE + COMMIT_MESSAGE_INSTRUCTIONS_2
             )
-            message_str += '\n'.join(_git_diff())
+            message_str += iw.diff(repo.rev_parse('HEAD').data.tree).decode('utf-8')
         new_message = edit_string(message_str, '.stgit-new.txt')
         new_message = new_message.split(COMMIT_MESSAGE_DEMARCATION_LINE)[0]
         new_message = '\n'.join(

--- a/stgit/commands/imprt.py
+++ b/stgit/commands/imprt.py
@@ -226,6 +226,7 @@ def __create_patch(
             message=message,
         )
         cd = update_commit_data(
+            stack.repository,
             cd,
             message=None,
             author=None,

--- a/stgit/commands/new.py
+++ b/stgit/commands/new.py
@@ -53,9 +53,8 @@ options = (
             action='store_true',
             short='show diff in patch commit message template',
             long='''
-        In addition to the names of files that have been changed, also show the textual changes that
-        are staged to be committed and the changes in the working tree that have
-        not yet been staged (i.e., like the output of git diff).''',
+        In addition to the names of files that have been changed, also show a
+        diff of staged and unstaged changes.''',
         ),
     ]
     + argparse.author_options()
@@ -100,6 +99,7 @@ def func(parser, options, args):
         committer=Person.committer(),
     )
     cd = update_commit_data(
+        stack.repository,
         cd,
         message=options.message,
         author=options.author(cd.author),


### PR DESCRIPTION
When originally setting up the diff for 'stg new', I incorrectly used git's
diff. I've since realized that stgit's diff is way better! We should be using
that!

What's wrong with 'git diff' irt stgit?
- 'git diff' gives you only unstaged files
- 'git diff --cached' gives you only staged files

For 'git commit', this distinction is great (since you're about to commit the
staged files). For 'stg new' however, you're not about to make a commit at all!
Both staged and unstaged files are important.

The solution: use 'stg diff', which gives a diff of both staged and unstaged
files:

	$ stg status
	M  staged
	 M unstaged

	$ stg diff
	diff --git a/staged b/staged
	index 5626abf..10a1890 100644
	--- a/staged
	+++ b/staged
	@@ -1 +1 @@
	-one
	+oneone
	diff --git a/unstaged b/unstaged
	index f719efd..10650ea 100644
	--- a/unstaged
	+++ b/unstaged
	@@ -1 +1 @@
	-two
	+twotwo

![image](https://user-images.githubusercontent.com/206988/125032106-7b499e00-e05b-11eb-8313-8e8f57888209.png)