### PR TITLE
Add link to coverage.io to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,3 +111,12 @@ By making a contribution to this project, I certify that:
 - Tests are added/modified that cover the bug fix or feature being
   added.
 - `make test` passes.
+
+### Code Coverage
+
+[![Coverage Status](https://coveralls.io/repos/github/stacked-git/stgit/badge.svg?branch=master)](https://coveralls.io/github/stacked-git/stgit?branch=master)
+
+We use [Coverage.py](https://coverage.readthedocs.io/en/coverage-5.5) to
+calculate code coverage on the repo. Run it with `make coverage`. There's a
+fancy GUI version tracking master at
+https://coveralls.io/github/stacked-git/stgit?branch=master.


### PR DESCRIPTION
See how this looks by scrolling to the bottom of https://github.com/topher200/stgit/blob/add-link-to-coverage.io-to-contributing.md/CONTRIBUTING.md

![image](https://user-images.githubusercontent.com/206988/125530065-c6a3d87d-0422-4a22-8697-03b1bd8ed429.png)
