### PR TITLE
Add coverage settings to ignore debug code.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,17 @@ source = ['stgit']
 branch = true
 parallel = true
 
+[tool.coverage.report]
+exclude_lines = [
+  "pragma: no cover",
+  "def __repr__",
+  "if self.debug",
+  "raise AssertionError",
+  "raise NotImplementedError",
+  "if 0:",
+  "if __name__ == .__main__.:",
+]
+
 [tool.coverage.html]
 title = 'StGit Coverage Report'
 show_contexts = true


### PR DESCRIPTION
Basic coverage.py config from their docs:
https://coverage.readthedocs.io/en/coverage-5.5/config.html#syntax

I just took the default example in their docs. I really wanted to grab the
`__repr__` thing; happy to modify this as sees fit.

This PR resolves the need to manually exclude debug lines with commits such as
8e946bac5f962a9e42f17cdb4081a25b2b7459cd.