### PR TITLE
new: commit.verbose is a boolean

### DIFF
--- a/stgit/commands/new.py
+++ b/stgit/commands/new.py
@@ -88,8 +88,7 @@ def func(parser, options, args):
     if options.verbose:
         verbose = options.verbose
     else:
-        verbose_int = config.getint('commit.verbose')
-        verbose = verbose_int > 0 if verbose_int else False
+        verbose = config.getbool('commit.verbose') or False
 
     cd = CommitData(
         tree=stack.head.data.tree,

--- a/t/t1003-new.sh
+++ b/t/t1003-new.sh
@@ -102,6 +102,14 @@ test_expect_success \
     stg show | grep "Patch Description Template"
 '
 
+test_expect_success \
+    'New with verbose config boolean option' '
+    test_config commit.verbose "true" &&
+    echo "Patch Description Template" > .git/patchdescr.tmpl &&
+    stg new --verbose verbose-config-bool-patch &&
+    stg show | grep "Patch Description Template"
+'
+
 test_expect_failure \
     'Patch with slash in name' '
     stg new bar/foo -m "patch bar/foo"


### PR DESCRIPTION
In #122, `new` got a `--verbose` flag that defaults to true if the
`commit.verbose` configuration in git is set. To determine whether the
configuration was set, the new feature used `config.getint`.

However, per the git-config documentation, `commit.verbose` can be a
boolean:

       commit.verbose
           A boolean or int to specify the level of verbose with git commit. See git-commit(1).

In fact, if `commit.verbose` is set to `true` right now, this will fail with,

    Value for "commit.verbose" is not an integer: "true"

Given that `config.getbool` will handle both, integers and booleans, use
that to determine if the configuration is set instead. Since
`config.getbool` will return `None` if unset, default to False rather than
None.
