### PR TITLE
'stg edit' aborts on empty patch description; add instructions.

### DIFF
--- a/stgit/commands/imprt.py
+++ b/stgit/commands/imprt.py
@@ -286,7 +286,7 @@ def __import_file(filename, options):
         f.close()
 
     message, patch_name, author_name, author_email, author_date, diff = parse_patch(
-        patch_data, contains_diff=True
+        patch_data, contains_diff=True, fail_on_empty_description=False
     )
 
     __create_patch(

--- a/stgit/commands/squash.py
+++ b/stgit/commands/squash.py
@@ -5,6 +5,7 @@ from stgit.commands.common import (
     DirectoryHasRepository,
     parse_patches,
     run_commit_msg_hook,
+    strip_comments,
 )
 from stgit.lib.transaction import StackTransaction, TransactionHalted
 
@@ -61,12 +62,6 @@ class SaveTemplateDone(Exception):
     pass
 
 
-def _strip_comments(message):
-    for line in message.splitlines():
-        if not line.startswith('#'):
-            yield line
-
-
 def _squash_patches(trans, patches, name, msg, save_template, no_verify=False):
     cd = trans.patches[patches[0]].data
     for pn in patches[1:]:
@@ -101,7 +96,7 @@ def _squash_patches(trans, patches, name, msg, save_template, no_verify=False):
         else:
             msg = utils.edit_string(msg, '.stgit-squash.txt')
 
-    msg = '\n'.join(_strip_comments(msg)).strip()
+    msg = '\n'.join(strip_comments(msg)).strip()
     if not msg:
         raise CmdException('Aborting squash due to empty commit message')
 

--- a/stgit/lib/edit.py
+++ b/stgit/lib/edit.py
@@ -11,6 +11,12 @@ from stgit.lib.git import Date, Person
 from stgit.lib.log import log_stack_state
 from stgit.out import out
 
+EDIT_MESSAGE_INSTRUCTIONS = """# Everything here is editable! You can modify the patch name, author,
+# date, commit message, and the diff (if --diff was given).
+# Lines starting with '#' will be ignored, and an empty message
+# aborts the edit.
+"""
+
 
 def update_patch_description(repo, cd, text, contains_diff):
     """Create commit with updated description.
@@ -68,10 +74,11 @@ def patch_desc(repo, cd, patch_name, append_diff, diff_flags, replacement_diff):
             'Date: %s' % cd.author.date.isoformat(),
             '',
             cd.message_str,
+            EDIT_MESSAGE_INSTRUCTIONS,
         ]
     ).encode(commit_encoding)
     if append_diff:
-        parts = [desc.rstrip(), b'', b'---', b'']
+        parts = [desc.rstrip(), b'---', b'']
         if replacement_diff:
             parts.append(replacement_diff)
         else:


### PR DESCRIPTION
This resolves https://github.com/stacked-git/stgit/issues/138 by...

1. Adding instruction hints on the *power* of 'stg edit'.
2. Stripping these new hint lines from the description.
3. Aborting 'stg edit' if all description lines are cleared.

From conversation on https://github.com/stacked-git/stgit/issues/138 it became
clear that aborting the 'edit' on an empty editor is correct.  This behavior
mirrors 'git commit' and 'stg squash'.

Previously, if a user cleared the 'stg edit' editor window, the patch
description would be cleared.  This is unintuative! Users likely expect that
this would abort the edit instead.

[![asciicast](https://asciinema.org/a/426044.svg)](https://asciinema.org/a/426044)