### PR TITLE
completion: Add --no-description for stg series

### DIFF
--- a/completion/stgit.zsh
+++ b/completion/stgit.zsh
@@ -714,7 +714,7 @@ __stg_patches_all() {
     declare -a patches
     local expl
     patches=(
-        ${(f)"$(_call_program all-patches stg series --noprefix --all 2>/dev/null)"}
+        ${(f)"$(_call_program all-patches stg series --no-description --noprefix --all 2>/dev/null)"}
     )
     _wanted -V all expl "patch" compadd ${patches:|words}
 }
@@ -723,7 +723,7 @@ __stg_patches_all_allow_dups() {
     declare -a patches
     local expl
     patches=(
-        ${(f)"$(_call_program all-patches stg series --noprefix --all 2>/dev/null)"}
+        ${(f)"$(_call_program all-patches stg series --no-description --noprefix --all 2>/dev/null)"}
     )
     _wanted -V all expl "patch" compadd ${patches}
 }
@@ -732,7 +732,7 @@ __stg_patches_applied() {
     declare -a patches
     local expl
     patches=(
-        ${(f)"$(_call_program applied-patches stg series --noprefix --applied 2>/dev/null)"}
+        ${(f)"$(_call_program applied-patches stg series --no-description --noprefix --applied 2>/dev/null)"}
     )
     _wanted -V applied expl "patch" compadd ${patches:|words}
 }
@@ -741,7 +741,7 @@ __stg_patches_hidden() {
     declare -a patches
     local expl
     patches=(
-        ${(f)"$(_call_program unhidden-patches stg series --noprefix --hidden 2>/dev/null)"}
+        ${(f)"$(_call_program unhidden-patches stg series --no-description --noprefix --hidden 2>/dev/null)"}
     )
     _wanted -V unapplied expl "patch" compadd ${patches:|words}
 }
@@ -750,7 +750,7 @@ __stg_patches_unapplied() {
     declare -a patches
     local expl
     patches=(
-        ${(f)"$(_call_program unapplied-patches stg series --noprefix --unapplied 2>/dev/null)"}
+        ${(f)"$(_call_program unapplied-patches stg series --no-description --noprefix --unapplied 2>/dev/null)"}
     )
     _wanted -V unapplied expl "patch" compadd ${patches:|words}
 }
@@ -759,7 +759,7 @@ __stg_patches_unhidden() {
     declare -a patches
     local expl
     patches=(
-        ${(f)"$(_call_program unhidden-patches stg series --noprefix --applied --unapplied 2>/dev/null)"}
+        ${(f)"$(_call_program unhidden-patches stg series --no-description --noprefix --applied --unapplied 2>/dev/null)"}
     )
     _wanted -V unapplied expl "patch" compadd ${patches:|words}
 }

--- a/stgit/completion/bash.py
+++ b/stgit/completion/bash.py
@@ -133,7 +133,9 @@ def write(f, stuff, indent=0):
 
 
 def patch_list_fun(type):
-    return fun('_%s_patches' % type, 'stg series --noprefix --%s' % type)
+    return fun(
+        '_%s_patches' % type, 'stg series --no-description --noprefix --%s' % type
+    )
 
 
 def file_list_fun(name, cmd):
@@ -170,7 +172,7 @@ def util():
         fun_desc(
             '_other_applied_patches',
             'List of all applied patches except the current patch.',
-            'stg series --noprefix --applied | grep -v "^$(stg top)$"',
+            'stg series --no-description --noprefix --applied | grep -v "^$(stg top)$"',
         ),
         fun(
             '_patch_range',

--- a/stgit/completion/fish.py
+++ b/stgit/completion/fish.py
@@ -81,21 +81,21 @@ function __fish_stg_stg_branches
 end
 
 function __fish_stg_applied_patches
-    command stg series --noprefix --applied 2>/dev/null
+    command stg series --no-description --noprefix --applied 2>/dev/null
 end
 
 function __fish_stg_other_applied_patches
     set -l top (command stg top 2>/dev/null)
-    command stg series --noprefix --applied 2>/dev/null \\
+    command stg series --no-description --noprefix --applied 2>/dev/null \\
         | string match --invert "$top"
 end
 
 function __fish_stg_unapplied_patches
-    command stg series --noprefix --unapplied 2>/dev/null
+    command stg series --no-description --noprefix --unapplied 2>/dev/null
 end
 
 function __fish_stg_hidden_patches
-    command stg series --noprefix --hidden 2>/dev/null
+    command stg series --no-description --noprefix --hidden 2>/dev/null
 end
 
 function __fish_stg_tags


### PR DESCRIPTION
If the `stg.series.description` config is set to `true`, then the output of
`stg series` always includes the first line of the commit messages.

For example,

    $ stg series
    + foo # Add foo
    + bar # Rename bar
    > baz # Remove baz

When the completion scripts call `stg series`, they use the full string,
including the description:

    $ stg refresh -p <tab>
    foo\ \#\ Add\ foo

To solve this, pass the `--no-description` flag to `stg series` in all
completion scripts when retrieving a list of patches.
