### PR TITLE
'stg rebase --interactive' learns 'hide' instruction

### DIFF
--- a/stgit/commands/common.py
+++ b/stgit/commands/common.py
@@ -333,6 +333,24 @@ def post_rebase(stack, applied, cmd_name, check_merged):
     return trans.execute('%s (reapply)' % cmd_name, iw)
 
 
+def hide_patches(stack, iw, patches):
+    def allow_conflicts(trans):
+        # Allow conflicts if the topmost patch stays the same.
+        if stack.patchorder.applied:
+            return trans.applied and trans.applied[-1] == stack.patchorder.applied[-1]
+        else:
+            return not trans.applied
+
+    trans = StackTransaction(stack, 'hide', allow_conflicts=allow_conflicts)
+    try:
+        to_push = trans.hide_patches(lambda pn: pn in patches)
+        for pn in to_push:
+            trans.push_patch(pn, iw)
+    except TransactionHalted:
+        pass
+    return trans.execute('hide', iw)
+
+
 def delete_patches(stack, iw, patches):
     def allow_conflicts(trans):
         # Allow conflicts if the topmost patch stays the same.


### PR DESCRIPTION
Pretty simple PR: 'stg rebase --interactive' learns 'hide' 
instruction to hide individual patches.

We could add an 'unhide' instruction but I haven't found 
a need for it yet!

[![asciicast](https://asciinema.org/a/HZycIMJeisCRP59mNHdZVDCgt.svg)](https://asciinema.org/a/HZycIMJeisCRP59mNHdZVDCgt)