### PR TITLE
Add target install-completion into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ dist:
 install:
 	$(PYTHON) setup.py install --prefix=$(prefix) --root=$(DESTDIR) --force
 
-.PHONY: all build dist install
+install-completion:
+	$(MAKE) -C completion install
+
+.PHONY: all build dist install install-completion
 
 doc:
 	$(MAKE) -C Documentation all

--- a/completion/Makefile
+++ b/completion/Makefile
@@ -1,0 +1,12 @@
+INSTALL ?= install
+
+prefix ?= $(HOME)/.local
+bashdir ?= $(prefix)/share/bash-completion/completions
+
+install: install-bash
+
+install-bash:
+	${INSTALL} -d -m 755 $(DESTDIR)$(bashdir)
+	${INSTALL} -T -m 644 stgit.bash $(DESTDIR)$(bashdir)/stg.bash
+
+.PHONY: install install-bash


### PR DESCRIPTION
For now install bash completion.
As bash user I'm not aware where other two should be placed.

Rename script during install, name should match command.
Base bash-completion loads "$cmd", "$cmd.bash", "_$cmd" at first use.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@yandex-team.ru>