### PR TITLE
Change os.system() call to avoid invoking 'python', which isn't always available

### DIFF
--- a/stgit/main.py
+++ b/stgit/main.py
@@ -142,7 +142,7 @@ def _main(argv):
     if cmd in ['-v', '--version', 'version']:
         print('Stacked Git %s' % get_version())
         os.system('git --version')
-        os.system('python --version')
+        os.system('%s --version' % sys.executable)
         return utils.STGIT_SUCCESS
     if cmd in ['copyright']:
         print(__copyright__)


### PR DESCRIPTION
Some systems (e.g. recent Ubuntu, Linux Mint) don't have a `python` command, but only `python2` or `python3`. This change invokes `os.system()` with the currently running interpreter, which avoids an error that occurs and is displayed when `python` is not available.