### PR TITLE
stack: strip trailing dots from short_name

### DIFF
--- a/stgit/lib/stack.py
+++ b/stgit/lib/stack.py
@@ -213,6 +213,9 @@ class Patches:
                 short_name = new_name
             else:
                 break
+        # Strip trailing dots again because the truncation may have
+        # left a trailing dot, which is not allowed
+        short_name = re.sub(r'\.+$', '', short_name)
         assert self.is_name_valid(short_name)
 
         if not unique:


### PR DESCRIPTION
Fixes assertion failure which can occur because the short_name is a
truncated version of the already-sanitized long_name, but the
truncation may leave a trailing dot.