### PR TITLE
Multiple diff-opts

### DIFF
--- a/src/argset.rs
+++ b/src/argset.rs
@@ -29,6 +29,7 @@ lazy_static! {
         .help("Extra options to pass to \"git diff\"")
         .takes_value(true)
         .allow_hyphen_values(true)
+        .multiple_occurrences(true)
         .value_name("OPTIONS")
         .value_hint(ValueHint::Other);
 }

--- a/src/cmd/diff.rs
+++ b/src/cmd/diff.rs
@@ -82,6 +82,6 @@ fn run(matches: &ArgMatches) -> Result<()> {
         matches.values_of_os("pathspecs"),
         matches.is_present("stat"),
         matches.value_of("color"),
-        matches.value_of("diff-opts"),
+        matches.values_of("diff-opts"),
     )
 }

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -168,7 +168,6 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
     let need_diffstat = template.contains("%(diffstat)");
 
     let opt_stdout = matches.is_present("stdout");
-    let diff_opts = matches.value_of("diff-opts");
     let mut series = format!(
         "# This series applies on Git commit {}\n",
         stack.base().id()
@@ -233,23 +232,14 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
             ),
         );
 
-        let diff_opts = diff_opts
-            .map(|opts| {
-                if opts.split_ascii_whitespace().any(|opt| opt == "--binary") {
-                    opts.to_string()
-                } else {
-                    format!("{opts} --binary")
-                }
-            })
-            .or_else(|| Some("--binary".to_string()));
-
         let diff = stupid.diff_tree_patch(
             parent_commit.tree_id(),
             patch_commit.tree_id(),
             <Option<Vec<OsString>>>::None,
             false,
             false,
-            diff_opts.as_deref(),
+            true,
+            matches.values_of("diff-opts"),
         )?;
 
         if need_diffstat {

--- a/src/cmd/patches.rs
+++ b/src/cmd/patches.rs
@@ -115,7 +115,8 @@ fn run(matches: &ArgMatches) -> Result<()> {
                     Some(&pathspecs),
                     false,
                     use_color,
-                    matches.value_of("diff-opts"),
+                    false,
+                    matches.values_of("diff-opts"),
                 )?;
                 stdout.write_all(&diff)?;
             }

--- a/src/cmd/show.rs
+++ b/src/cmd/show.rs
@@ -156,6 +156,6 @@ fn run(matches: &ArgMatches) -> Result<()> {
         matches.values_of_os("path_limits"),
         opt_stat,
         matches.value_of("color"),
-        matches.value_of("diff-opts"),
+        matches.values_of("diff-opts"),
     )
 }

--- a/src/patchedit/mod.rs
+++ b/src/patchedit/mod.rs
@@ -600,6 +600,7 @@ impl<'a, 'repo> EditBuilder<'a, 'repo> {
                     <Option<Vec<OsString>>>::None,
                     true,
                     false,
+                    false,
                     None,
                 )?
             } else {

--- a/src/stupid.rs
+++ b/src/stupid.rs
@@ -389,7 +389,7 @@ impl<'repo, 'index> StupidContext<'repo, 'index> {
         pathspecs: Option<I>,
         stat: bool,
         color_opt: Option<&str>,
-        diff_opts: Option<&str>,
+        diff_opts: Option<clap::Values<'_>>,
     ) -> Result<()>
     where
         I: IntoIterator<Item = S>,
@@ -406,9 +406,7 @@ impl<'repo, 'index> StupidContext<'repo, 'index> {
         }
 
         if let Some(diff_opts) = diff_opts {
-            for opt in diff_opts.split_ascii_whitespace() {
-                command.arg(opt);
-            }
+            command.args(diff_opts);
         }
 
         command.arg(revspec);
@@ -508,7 +506,8 @@ impl<'repo, 'index> StupidContext<'repo, 'index> {
         pathspecs: Option<I>,
         full_index: bool,
         color: bool,
-        diff_opts: Option<&str>,
+        binary: bool,
+        diff_opts: Option<clap::Values<'_>>,
     ) -> Result<Vec<u8>>
     where
         I: IntoIterator<Item = S>,
@@ -522,8 +521,11 @@ impl<'repo, 'index> StupidContext<'repo, 'index> {
         if color {
             command.arg("--color");
         }
+        if binary {
+            command.arg("--binary");
+        }
         if let Some(diff_opts) = diff_opts {
-            command.args(diff_opts.split_ascii_whitespace());
+            command.args(diff_opts);
         }
         command.args([tree1.to_string(), tree2.to_string()]);
         if let Some(pathspecs) = pathspecs {
@@ -927,7 +929,7 @@ impl<'repo, 'index> StupidContext<'repo, 'index> {
         pathspecs: Option<I>,
         stat: bool,
         color_opt: Option<&str>,
-        diff_opts: Option<&str>,
+        diff_opts: Option<clap::Values<'_>>,
     ) -> Result<()>
     where
         I: IntoIterator<Item = S>,
@@ -946,9 +948,7 @@ impl<'repo, 'index> StupidContext<'repo, 'index> {
         }
 
         if let Some(diff_opts) = diff_opts {
-            for opt in diff_opts.split_ascii_whitespace() {
-                command.arg(opt);
-            }
+            command.args(diff_opts);
         }
 
         for oid in oids {

--- a/t/t0005-show.sh
+++ b/t/t0005-show.sh
@@ -63,6 +63,11 @@ test_expect_success 'Bad diff opts' '
     grep -e "unrecognized argument: --this-is-bad" err
 '
 
+test_expect_success 'Multiple diff opts' '
+    stg show --diff-opts=--shortstat --diff-opts --name-only patch-bbb |
+    grep -e "foo.txt"
+'
+
 test_expect_success 'Show patch range' '
     stg show patch-bbb..patch-ddd > show-range.txt &&
     test $(grep -c -E "\+(aaa|bbb|ccc|ddd)" show-range.txt) = "3" &&

--- a/t/t0006-patches.sh
+++ b/t/t0006-patches.sh
@@ -106,4 +106,9 @@ test_expect_success 'With diff output' '
     test $(cat even-diff.log | grep -c -E "p(0|1|3) message") = "3"
 '
 
+test_expect_success 'With diff output and diff-opts' '
+    stg patches --diff-opts=--abbrev -O --name-only --diff even.txt > even-diff2.log
+    test $(cat even-diff2.log | grep -c -E "even.txt") = "3"
+    test $(cat even-diff2.log | grep -c -E "p(0|1|3) message") = "3"
+'
 test_done

--- a/t/t2400-diff.sh
+++ b/t/t2400-diff.sh
@@ -47,6 +47,10 @@ test_expect_success 'Diff with some local changes' '
     test_cmp add-foo.diff add-foo2.diff
 '
 
+test_expect_success 'Diff with multiple diff-opts' '
+    stg diff --diff-opts=--shortstat -O --name-only | grep -e "foo.txt"
+'
+
 test_expect_success 'Refresh patch' '
     stg refresh
 '

--- a/t/t4300-export.sh
+++ b/t/t4300-export.sh
@@ -22,6 +22,13 @@ test_expect_success 'Export to directory' '
     done
     '
 
+test_expect_success 'Export with multiple diff-opts' '
+    stg export -d export2 -O --minimal -O --no-indent-heuristic &&
+    for i in 1 2 3 4 5; do
+      test_path_is_file export2/patch-$i
+    done
+    '
+
 test_expect_success 'Reimport directory export' '
     stg delete $(stg series --noprefix) &&
     stg import -s export1/series &&


### PR DESCRIPTION
Solves Issue #187
Not super-happy about adding the binary-argument to the diff_tree_patch function but if we can have an argument for `--color` I suppose we can have one for `--binary` too and it makes the handling of `--diff-opts` a lot simpler.