### PR TITLE
Use "patch" extension when editing a patch with a diff

### DIFF
--- a/src/patchedit/interactive.rs
+++ b/src/patchedit/interactive.rs
@@ -30,6 +30,9 @@ pub(crate) static EDIT_INSTRUCTION_EDITABLE_DIFF: &str = "# The diff below may b
 /// Default file name for interactively editable patch description.
 static EDIT_FILE_NAME: &str = ".stgit-edit.txt";
 
+/// Default file name for interactively editable patch description with diff.
+static EDIT_FILE_NAME_DIFF: &str = ".stgit-edit.patch";
+
 /// Conduct interactive patch edit session.
 ///
 /// The patch description is written to a file, the user's editor of choice is invoked,
@@ -39,7 +42,12 @@ pub(super) fn edit_interactive(
     config: &git2::Config,
 ) -> Result<EditedPatchDescription> {
     {
-        let file = File::create(EDIT_FILE_NAME)?;
+        let filename = if patch_desc.diff.is_some() {
+            EDIT_FILE_NAME_DIFF
+        } else {
+            EDIT_FILE_NAME
+        };
+        let file = File::create(filename)?;
         let mut stream = BufWriter::new(file);
         patch_desc.write(&mut stream)?;
     }


### PR DESCRIPTION
```
*  Use "patch" extension when editing a patch with a diff
   
   It enables syntax highlighting in many editors. The file names are the
   same as in the Python implementation.
```

See https://github.com/stacked-git/stgit/blob/v1.5/stgit/lib/edit.py#L105 for the Python implementation.

Tested locally by `stg edit` and `stg edit -d`.