### PR TITLE
Upgrade to git2 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
 dependencies = [
  "bitflags",
  "libc",
@@ -338,9 +338,9 @@ checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.14.0+1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bstr = { version = "0.2", default-features = false, features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "3.2", default-features = false, features = ["color", "std", "suggestions", "wrap_help"] }
 encoding_rs = "0.8"
-git2 = { version = "0.13", default-features = false }
+git2 = { version = "0.15", default-features = false }
 indexmap = "1.8"
 lazy_static = "~1.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/alias.rs
+++ b/src/alias.rs
@@ -97,8 +97,9 @@ where
     F: Fn(&str) -> bool,
 {
     let mut aliases = get_default_aliases();
-
-    for entry in config.entries(None)?.flatten() {
+    let mut iter = config.entries(None)?;
+    while let Some(entry) = iter.next() {
+        let entry = entry?;
         if let Some(name) = entry.name_bytes().strip_prefix(b"stgit.alias.") {
             let name = name.to_str().map_err(|_| {
                 anyhow!(

--- a/src/stack/stack.rs
+++ b/src/stack/stack.rs
@@ -86,15 +86,17 @@ impl<'repo> Stack<'repo> {
         }
         state_ref.delete()?;
         let mut config_to_delete: Vec<_> = Vec::new();
-        for entry in config
-            .entries(Some(&format!("branch.{branch_name}.stgit")))?
-            .into_iter()
+
         {
-            let entry = entry?;
-            if let Some(name) = entry.name() {
-                config_to_delete.push(name.to_string());
+            let mut entries = config.entries(Some(&format!("branch.{branch_name}.stgit")))?;
+            while let Some(entry) = entries.next() {
+                let entry = entry?;
+                if let Some(name) = entry.name() {
+                    config_to_delete.push(name.to_string());
+                }
             }
         }
+
         for name_to_delete in config_to_delete {
             config.remove(&name_to_delete)?;
         }


### PR DESCRIPTION
Since 0.13, git2 has seen [many changes][1], including rust-lang/git2-rs#791
which should address the extensions.worktreeConfig issue in #195.

[1]: https://github.com/rust-lang/git2-rs/compare/0.13.0...0.15.0

The upgrade required fixing uses of [ConfigEntries][2] because it's no
longer an iterator.
However, it provides an API that lends itself well to a `while let` statement,
which provides a for-loop-like experience, so the fix was straightforward.

[2]: https://docs.rs/git2/0.15.0/git2/struct.ConfigEntries.html
