### PR TITLE
Set up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds a dependabot configuration to check for updates of dependencies once a week.

Based on comments in https://github.com/stacked-git/stgit/pull/206#issuecomment-1242573201.
Feel free to close if you'd rather update dependencies on your own schedule.