### PR TITLE
Fix rustc 1.64 lints

### DIFF
--- a/src/cmd/push.rs
+++ b/src/cmd/push.rs
@@ -188,7 +188,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
         .with_output_stream(get_color_stdout(matches))
         .transact(|trans| {
             if opt_settree {
-                for (i, patchname) in (&patches).iter().enumerate() {
+                for (i, patchname) in patches.iter().enumerate() {
                     let is_last = i + 1 == patches.len();
                     trans.push_tree(patchname, is_last)?;
                 }

--- a/src/cmd/refresh.rs
+++ b/src/cmd/refresh.rs
@@ -171,7 +171,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
         &stack,
         &config,
         matches,
-        matches.contains_id("update").then(|| &patchname),
+        matches.contains_id("update").then_some(&patchname),
     )?;
 
     let mut log_msg = "refresh ".to_string();


### PR DESCRIPTION
The clippy build on master broke with the following errors:

```
the compiler would automatically borrow
   --> src/cmd/push.rs:191:39
    |
191 |                 for (i, patchname) in (&patches).iter().enumerate() {
    |                                       ^^^^^^^^^^ help: change this to: `patches`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: unnecessary closure used with `bool::then`
   --> src/cmd/refresh.rs:174:9
    |
174 |         matches.contains_id("update").then(|| &patchname),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------------------
    |                                       |
    |                                       help: use `then_some(..)` instead: `then_some(&patchname)`
    |
    = note: `-D clippy::unnecessary-lazy-evaluations` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations
```

https://github.com/stacked-git/stgit/actions/runs/3108127571/jobs/5036983076

These checks were added in the recently released Rust 1.64.

This change fixes both issues.
