### PR TITLE
Don't split passthrough options on whitespace

### DIFF
--- a/completion/stgit.zsh
+++ b/completion/stgit.zsh
@@ -1208,24 +1208,45 @@ __stg_add_args_trailers() {
 }
 
 __stg_git_diff_opts() {
-    local -a diff_opts
-    diff_opts=(${(z)"$(_call_program git-diff-options "git ${__stg_C_args} diff-tree --git-completion-helper")"})
-    __stg_git_command_successful $pipestatus || return 1
-    _wanted git-diff-options expl "diff option" compadd -a diff_opts
+    words=('git' ${(@)__stg_C_args} 'diff-tree')
+    # Needs a way to know word indices for opt_args values to only provide through CURRENT.
+    #
+    # words+=(${(0)opt_args[-O]} ${(0)opt_args[--diff-opts]})
+    words+=("$PREFIX$SUFFIX")
+    (( CURRENT = $#words ))
+
+    local _comp_command1 _comp_command2 _comp_command
+    _set_command
+    _message -e git-diff-option 'diff option' && \
+        _dispatch "$_comp_command" "$_comp_command1" "$_comp_command2" -default-
 }
 
 __stg_git_format_patch_opts() {
-    local -a format_patch_opts
-    format_patch_opts=(${(z)"$(_call_program git-format-patch-options "git ${__stg_C_args} format-patch --git-completion-helper")"})
-    __stg_git_command_successful $pipestatus || return 1
-    _wanted git-format-patch-options expl "format-patch option" compadd -a format_patch_opts
+    words=('git' ${(@)__stg_C_args} 'format-patch')
+    # Needs a way to know word indices for opt_args values to only provide through CURRENT.
+    #
+    # words+=(${(0)opt_args[-G]} ${(0)opt_args[--git-opts]})
+    words+=("$PREFIX$SUFFIX")
+    (( CURRENT = $#words ))
+
+    local _comp_command1 _comp_command2 _comp_command
+    _set_command
+    _message -e git-format-patch-option 'format-patch option' && \
+        _dispatch "$_comp_command" "$_comp_command1" "$_comp_command2" -default-
 }
 
 __stg_git_send_email_opts() {
-    local -a send_email_opts
-    send_email_opts=(${(z)"$(_call_program git-send-email-options "git ${__stg_C_args} send-email --git-completion-helper")"})
-    __stg_git_command_successful $pipestatus || return 1
-    _wanted git-send-email-options expl "send-email option" compadd -a send_email_opts
+    words=('git' ${(@)__stg_C_args} 'send-email')
+    # Needs a way to know word indices for opt_args values to only provide through CURRENT.
+    #
+    # words+=(${(0)opt_args[-G]} ${(0)opt_args[--git-opts]})
+    words+=("$PREFIX$SUFFIX")
+    (( CURRENT = $#words ))
+
+    local _comp_command1 _comp_command2 _comp_command
+    _set_command
+    _message -e git-send-email-option 'send-email option' && \
+        _dispatch "$_comp_command" "$_comp_command1" "$_comp_command2" -default-
 }
 
 __stg_revisions () {

--- a/src/argset.rs
+++ b/src/argset.rs
@@ -36,14 +36,18 @@ pub(crate) fn merged_arg() -> Arg {
 
 /// The `--diff-opts`/`-O` option for pass-through to subordinate `git` processes.
 pub(crate) fn diff_opts_arg() -> Arg {
-    Arg::new("diff-opts")
+    Arg::new("git-diff-opts")
         .long("diff-opts")
         .short('O')
         .help("Extra options to pass to \"git diff\"")
+        .long_help(
+            "Pass additional options <git-diff-options> to `git diff`. \
+             See the git-diff(1) man page.",
+        )
         .num_args(1)
         .allow_hyphen_values(true)
         .action(clap::ArgAction::Append)
-        .value_name("options")
+        .value_name("git-diff-options")
         .value_hint(clap::ValueHint::Other)
 }
 
@@ -100,12 +104,8 @@ pub(crate) fn get_diff_opts(
         }
     }
 
-    if let Some(values) = matches.get_many::<String>("diff-opts") {
-        for value in values {
-            for arg in value.split_ascii_whitespace() {
-                opts.push(String::from(arg))
-            }
-        }
+    if let Some(values) = matches.get_many::<String>("git-diff-opts") {
+        opts.extend(values.cloned());
     }
 
     if force_full_index {

--- a/src/cmd/completion/bash.rs
+++ b/src/cmd/completion/bash.rs
@@ -219,13 +219,13 @@ fn insert_compreply(script: &mut ShStream, arg: &clap::Arg) {
             "committish" => script.line(
                 "mapfile -t COMPREPLY < <(compgen -W \"$(_all_branches) $(_tags) $(_remotes)\")",
             ),
-            "diff-opts" => {
-                script.line("mapfile -t COMPREPLY < <(compgen -W \"$(_diff_opts)\" -- \"$cur\")")
+            "git-diff-opts" => {
+                script.line("mapfile -t COMPREPLY < <(compgen -W \"$(_git_diff_opts)\" -- \"$cur\")")
             }
             "git-format-patch-opts" => script
-                .line("mapfile -t COMPREPLY < <(compgen -W \"$(_format_patch_opts)\" -- \"$cur\")"),
+                .line("mapfile -t COMPREPLY < <(compgen -W \"$(_git_format_patch_opts)\" -- \"$cur\")"),
             "git-send-email-opts" => script
-                .line("mapfile -t COMPREPLY < <(compgen -W \"$(_send_email_opts)\" -- \"$cur\")"),
+                .line("mapfile -t COMPREPLY < <(compgen -W \"$(_git_send_email_opts)\" -- \"$cur\")"),
             "patch" => script
                 .line("mapfile -t COMPREPLY < <(compgen -W \"$(_visible_patches)\" -- \"$cur\")"),
             "patchranges" => script.line("_patch_range \"$(_visible_patches)\""),
@@ -574,17 +574,17 @@ _known_files ()
     test "$g" && __git ls-files "${cur}*"
 }
 
-_diff_opts ()
+_git_diff_opts ()
 {
     __git diff-tree --git-completion-helper
 }
 
-_format_patch_opts ()
+_git_format_patch_opts ()
 {
     __git format-patch --git-completion-helper
 }
 
-_send_email_opts()
+_git_send_email_opts()
 {
     __git send-email --git-completion-helper
 }

--- a/src/cmd/completion/fish.rs
+++ b/src/cmd/completion/fish.rs
@@ -363,7 +363,7 @@ fn get_arg_completion_params(arg: &clap::Arg) -> ShStream {
             "branch" | "ref-branch" => params.word("-xa '(__fish_stg_stg_branches)'"),
             "branch-any" => params.word("-xa '(__fish_stg_all_branches)'"),
             "committish" => params.word("-xa '(__fish_stg_commit)'"),
-            "diff-opts" => params.word("-xa '(__fish_stg_git_diff_opts)'"),
+            "git-diff-opts" => params.word("-xa '(__fish_stg_git_diff_opts)'"),
             "git-format-patch-opts" => params.word("-xa '(__fish_stg_git_format_patch_opts)'"),
             "git-send-email-opts" => params.word("-xa '(__fish_stg_git_send_email_opts)'"),
             "patch" | "patchranges" => params.word("-kxa '(__fish_stg_patches -A -U)'"),

--- a/src/cmd/email/format.rs
+++ b/src/cmd/email/format.rs
@@ -44,11 +44,7 @@ pub(super) fn command() -> clap::Command {
              \n\
              Many aspects of the format behavior may be controlled via `format.*` \
              configuration values. Refer to the git-config(1) and git-format-patch(1) \
-             man pages for more details.\n\
-             \n\
-             `stg email format` is a wrapper for `git format-patch`. Additional \
-             options for `git format-patch` may be specified on the command line after \
-             a `--` separator. See the git-format-patch(1) man page.",
+             man pages for more details.",
         )
         .override_usage(
             "stg email format [OPTIONS] <patch>...\n       \
@@ -76,6 +72,10 @@ pub(super) fn command() -> clap::Command {
                 .long("git-opts")
                 .short('G')
                 .help("Extra options to pass to \"git format-patch\"")
+                .long_help(
+                    "Pass additional options <git-options> to `git format-patch`. \
+                     See the git-format-patch(1) man page.",
+                )
                 .allow_hyphen_values(true)
                 .action(clap::ArgAction::Append)
                 .value_name("git-options"),
@@ -506,11 +506,7 @@ pub(super) fn dispatch(matches: &clap::ArgMatches) -> Result<()> {
     let mut format_args = format_args.drain(..).map(|(_, s)| s).collect::<Vec<_>>();
 
     if let Some(values) = matches.get_many::<String>("git-format-patch-opts") {
-        for value in values {
-            for arg in value.split_ascii_whitespace() {
-                format_args.push(String::from(arg))
-            }
-        }
+        format_args.extend(values.cloned());
     }
 
     {

--- a/src/cmd/email/send.rs
+++ b/src/cmd/email/send.rs
@@ -37,10 +37,7 @@ pub(super) fn command() -> clap::Command {
              configuration options. In particular, it is recommended to statically \
              configure SMTP details such as `sendemail.smtpServer`, \
              `sendemail.smtpUser`, etc. Refer to git-config(1) and git-send-email(1) \
-             man pages for more detail on all the available configuration options.\n\
-             \n\
-             Additional options for `git send-email` may be specified on the command \
-             line after a `--` separator. See the git-send-email(1) man page.",
+             man pages for more detail on all the available configuration options.",
         )
         .override_usage(
             "stg email send [OPTIONS] <file|directory>...\n       \
@@ -82,6 +79,10 @@ pub(super) fn command() -> clap::Command {
                 .long("git-opts")
                 .short('G')
                 .help("Extra options to pass to \"git send-email\"")
+                .long_help(
+                    "Pass additional options <git-options> to `git send-email`. \
+                     See the git-send-email(1) man page.",
+                )
                 .allow_hyphen_values(true)
                 .action(clap::ArgAction::Append)
                 .value_name("git-options"),
@@ -458,11 +459,7 @@ pub(super) fn dispatch(matches: &clap::ArgMatches) -> Result<()> {
     let mut send_args = send_args.drain(..).map(|(_, s)| s).collect::<Vec<_>>();
 
     if let Some(values) = matches.get_many::<String>("git-send-email-opts") {
-        for value in values {
-            for arg in value.split_ascii_whitespace() {
-                send_args.push(String::from(arg))
-            }
-        }
+        send_args.extend(values.cloned());
     }
 
     let mut sources = sources;


### PR DESCRIPTION
Otherwise, `stg email send -G '--subject=Latest patch'` translates to `git send-mail '--subject=Latest' 'patch'`, and the command errors with
```
error: `git send-email`: fatal: ambiguous argument 'patch': unknown revision or path not in the working tree.
```

Also, Zsh completion reuses the current `git` completion, whatever it is. Ideally, `stg -C foo diff -D --bar -D --baz=` would complete the same as `git -C foo diff --bar --baz=`, but it's currently limited to completing the same as `git -C foo diff --baz=`, so multi-word options won't complete properly (not that they would before). If Zsh provided a companion associative array to `opt_args` that contained indices for each value represented in `opt_args`, we could filter to the current word and provide virtually perfect completion, but this will involve submitting a patch to Zsh to enhance both `comparguments` and `_arguments`.