### PR TITLE
fix: Install zsh completions as _stgit instead of _stg

### DIFF
--- a/completion/Makefile
+++ b/completion/Makefile
@@ -25,7 +25,7 @@ install-fish: stg.fish
 
 install-zsh:
 	$(INSTALL) -d -m 755 $(DESTDIR)$(zshdir)
-	$(INSTALL) -T -m 644 stgit.zsh $(DESTDIR)$(zshdir)/_stg
+	$(INSTALL) -T -m 644 stgit.zsh $(DESTDIR)$(zshdir)/_stgit
 
 .PHONY: install install-bash install-fish install-zsh
 


### PR DESCRIPTION
Fixes #102 again, but more broadly, fixes the installation of the zsh completion script.

I don’t know exactly what file was loaded when the file was installed under `_stg`, but as soon as I renamed it `_stgit`, the behavior was as expected.

By no means am I an expert in Zsh completion, so don’t hesitate to discard this PR if it is incorrect.