### PR TITLE
docs: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@
   `$XDG_CONFIG_HOME/stgit/templates/` and `$HOME/.stgit/templates`. This
   search strategy is consistent with how git looks for the global config
   file.
-- The new `--signoff` patch edit option supercedes the deprecated
+- The new `--signoff` patch edit option supersedes the deprecated
   `--sign` and `--sign-by` options. `--signoff` without its optional
   value does the same thing as `--sign`, while `--signoff=<value>` does
   the same thing as `--sign-by=<value>`.
@@ -178,7 +178,7 @@
 - Avoid case insensitive patch name collisions. On operating systems
   with case-insensitive paths, patch names that only differ by case lead
   to patch reference collisions. StGit now ensures that patch names are
-  distinct under case insensitive comparisions.
+  distinct under case insensitive comparisons.
 - `stg pull` and `stg rebase` record updated stack state instead of
   deferring until the next stack-modifying command to do so.
 
@@ -213,7 +213,7 @@
 - Repair check for modifications to stack by external tools.
 - `stg pull` and `stg rebase` record updated stack state instead of
   deferring until the next stack-modifying command to do so.
-- Improve patch appliction with `git apply --3way` when pushing` (#225)
+- Improve patch application with `git apply --3way` when pushing` (#225)
 - Zsh completion for `--diff-opt` accommodates multiple occurrences
 
 
@@ -340,7 +340,7 @@
 - Bash completions for shell aliases now fallback to filename
   completions (#191).
 - Help options listings now ensure --color and --help are shown last.
-- Various zsh completion improvments:
+- Various zsh completion improvements:
   - Add descriptions for --color values
   - Complete -O/--diff-opts values (using `git diff-tree --git-completion-helper`)
   - Comprehend `stg -C <dir>` options
@@ -399,7 +399,7 @@
 - Avoid case insensitive patch name collisions. On operating systems
   with case-insensitive paths, patch names that only differ by case lead
   to patch reference collisions. StGit now ensures that patch names are
-  distinct under case insensitive comparisions.
+  distinct under case insensitive comparisons.
 - Add missing `-t` short option for `--set-tree` for `stg edit`.
 - Add missing `-k` short option for `--keep`.
 
@@ -486,7 +486,7 @@
 - `stg show` diff can now be limited to certain paths by specifying path
   limits on the command line.
 - `stg show` diff output respects the `--color` option.
-- The new `--signoff` patch edit option supercedes the deprecated
+- The new `--signoff` patch edit option supersedes the deprecated
   `--sign` and `--sign-by` options. `--signoff` without its optional
   value does the same thing as `--sign`, while `--signoff=<value>` does
   the same thing as `--sign-by=<value>`.
@@ -827,7 +827,7 @@
 - `stg diff --range` detects some invalid values (e.g. `-r ..`).
 - Date parsing is now more portable, only use platform specific `date`
   as last parsing option. Affects, e.g., `stg refresh --authdate`.
-- Repaired seach path for templates to avoid looking in Python
+- Repaired search path for templates to avoid looking in Python
   site-packages directory.
 - Ensure stdout and stderr are flushed. Rarely affected `stg diff`.
 - `stg repair` will now fail if extra command line arguments are

--- a/completion/stgit.zsh
+++ b/completion/stgit.zsh
@@ -705,7 +705,7 @@ _stg-import() {
         '(-p --strip)'{-p+,--strip=}'[remove N leading directories from diff paths]:num'
         '(-t --stripname)'{-t,--stripname}'[strip number and extension from patch name]'
         '-C=[ensure N lines of surrounding context for each change]:num'
-        '(-i --ignore)'{-i,--ignore}'[ingore applied patches in series]'
+        '(-i --ignore)'{-i,--ignore}'[ignore applied patches in series]'
         '--replace[replace unapplied patches in series]'
         '--reject[leave rejected hunks in .rej files]'
         '--keep-cr[do not remove CR from email lines ending with CRLF]'

--- a/contrib/stg-cvs
+++ b/contrib/stg-cvs
@@ -29,7 +29,7 @@ set -e
 # LIMITATIONS
 # - this is only a proof-of-concept prototype
 # - lacks an "init" command (see above)
-# - "commit" does not ensure the base is uptodate before trying to
+# - "commit" does not ensure the base is up-to-date before trying to
 #   commit (but hey, it's CVS ;): better "stg-cvs pull" first
 # - "commit" can only commit a single patch
 # - not much robustness here

--- a/contrib/stg-gitk
+++ b/contrib/stg-gitk
@@ -91,7 +91,7 @@ elif grep -q -- --argscmd "$(command -v gitk)"; then
         gitk --argscmd="$0 --refs $branches" "$@"
     fi
 else
-    # This gitk does not support --argscmd, just compute refs onces
+    # This gitk does not support --argscmd, just compute refs once
     # shellcheck disable=SC2046
     gitk $(printrefs) "$@"
 fi

--- a/contrib/stg-show
+++ b/contrib/stg-show
@@ -11,7 +11,7 @@ set -e
 
 command=(git show)
 
-# subsitute git id's for stg ones until --
+# substitute git id's for stg ones until --
 while [ "$#" -gt 0 ]; do
     case "$1" in
 	--) break ;;

--- a/examples/gitconfig
+++ b/examples/gitconfig
@@ -52,7 +52,7 @@
 	#rebasecmd = git reset
 
 	# "stg pull" policy.  This is the repository default, which can be
-	# overriden on a per-branch basis using branch.*.stgit.pull-policy
+	# overridden on a per-branch basis using branch.*.stgit.pull-policy
 	# By default:
 	#pull-policy = pull
 	# To support remote rewinding parent branches:

--- a/src/cmd/email/format.rs
+++ b/src/cmd/email/format.rs
@@ -142,7 +142,7 @@ fn format_options() -> Vec<Arg> {
                  '--reroll-count=4.4', or '--reroll-count=4rev2' are allowed), but the \
                  downside of using such a reroll-count is that the \
                  range-diff/interdiff with the previous version does not state exactly \
-                 which version the new interation is compared against.",
+                 which version the new iteration is compared against.",
             )
             .value_name("n")
             .num_args(1),

--- a/src/cmd/pick.rs
+++ b/src/cmd/pick.rs
@@ -41,7 +41,7 @@ fn make() -> clap::Command {
              '--revert' option.\n\
              \n\
              When using the '--expose' option, the format of the commit message is \
-             determinded by the 'stgit.pick.expose-format' configuration option. This \
+             determined by the 'stgit.pick.expose-format' configuration option. This \
              option is a format string as may be supplied to the '--pretty' option of \
              'git show'. The default is \"format:%B%n(imported from commit %H)\", \
              which appends the commit hash of the picked commit to the patch's commit \

--- a/src/cmd/refresh.rs
+++ b/src/cmd/refresh.rs
@@ -43,7 +43,7 @@ fn make() -> clap::Command {
              Refresh will warn if the index is dirty, and require use of \
              either the '--index' or '--force' options to override this \
              check. This is to prevent accidental full refresh when only \
-             some changes were staged using git add interative mode.\n\
+             some changes were staged using git add interactive mode.\n\
              \n\
              You may optionally list one or more files or directories \
              relative to the current working directory; if you do, only \

--- a/src/cmd/uncommit.rs
+++ b/src/cmd/uncommit.rs
@@ -53,7 +53,7 @@ fn make() -> clap::Command {
         )
         .arg(
             Arg::new("patchname")
-                .help("Patch names for the uncommited commits")
+                .help("Patch names for the uncommitted commits")
                 .num_args(1..)
                 .value_parser(clap::value_parser!(PatchName)),
         )

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -16,7 +16,7 @@ use crate::stupid::Stupid;
 /// message encoding, that header is not always present or correct in commits found in
 /// the wild. And yet another layer of complication emerges due to [`git2`] (and the
 /// underlying `libgit2`) not having any capability of its own to decode, encode, or
-/// reencode commit messages. With [`git2`], it entirely up to the application to make
+/// re-encode commit messages. With [`git2`], it entirely up to the application to make
 /// sense of the raw commit message bytes when any non-UTF-8 encoding comes into play.
 ///
 /// StGit aims to always create commit objects will correct/correctly-identified
@@ -165,7 +165,7 @@ impl<'a> CommitMessage<'a> {
                                 target_encoding.encode(&message);
                             if any_replacements {
                                 Err(anyhow!(
-                                    "Failed to reencode commit message from `{}` to `{}`",
+                                    "Failed to re-encode commit message from `{}` to `{}`",
                                     current_encoding.name(),
                                     target_encoding.name(),
                                 ))

--- a/src/patchedit/description.rs
+++ b/src/patchedit/description.rs
@@ -29,7 +29,7 @@ pub(super) struct EditablePatchDescription {
     /// Patch name.
     ///
     /// Should be the original or default patch name when setting up an interactive
-    /// edit, but may be `None` after interative edit (i.e. if the user removes the name
+    /// edit, but may be `None` after interactive edit (i.e. if the user removes the name
     /// or the entire `Patch:` header).
     pub patchname: Option<PatchName>,
 

--- a/src/patchedit/mod.rs
+++ b/src/patchedit/mod.rs
@@ -368,7 +368,7 @@ impl<'a, 'repo> EditBuilder<'a, 'repo> {
         self
     }
 
-    /// Set the patch name to use in the interacte edit template.
+    /// Set the patch name to use in the interactive edit template.
     ///
     /// This takes precedence over [`EditBuilder::original_patchname()`], when set.
     /// Setting to `None` will cause the edit template to have an empty `Patch:` field.
@@ -502,7 +502,7 @@ impl<'a, 'repo> EditBuilder<'a, 'repo> {
             // nominal i18n.commitEncoding and/or it is not valid UTF-8.
             //
             // The approach here is to try to get the author signature from
-            // whereever possible *before* even trying to inspect/decode the author
+            // wherever possible *before* even trying to inspect/decode the author
             // from the existing patch commit. I.e. it will be an error if the
             // existing patch commit's author is broken, but only if the author
             // signature has to be derived from that commit.

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -188,7 +188,7 @@ pub(crate) trait TimeExtended {
 impl TimeExtended for git2::Time {
     fn datetime(&self) -> DateTime<FixedOffset> {
         FixedOffset::east_opt(self.offset_minutes() * 60)
-            .expect("tz offset minues is in bounds")
+            .expect("tz offset minutes is in bounds")
             .timestamp_opt(self.seconds(), 0)
             .unwrap()
     }

--- a/src/stack/transaction/builder.rs
+++ b/src/stack/transaction/builder.rs
@@ -93,7 +93,7 @@ impl<'repo> TransactionBuilder<'repo> {
     }
 
     /// Determines whether the branch and stack metadata refs should be updated when the
-    /// transaction executes succesfully. This is the default. Disabling this is only useful
+    /// transaction executes successfully. This is the default. Disabling this is only useful
     /// in very special circumstances (e.g. for `stg uncommit`).
     #[must_use]
     pub(crate) fn set_head(mut self, yes: bool) -> Self {

--- a/src/stupid/mod.rs
+++ b/src/stupid/mod.rs
@@ -408,7 +408,7 @@ impl<'repo, 'index> StupidContext<'repo, 'index> {
             .env("GIT_AUTHOR_EMAIL", author_email)
             .env("GIT_COMMITTER_NAME", committer_name)
             .env("GIT_COMMITTER_EMAIL", committer_email)
-            // TODO: reencode dates?
+            // TODO: re-encode dates?
             .env("GIT_AUTHOR_DATE", author.epoch_time_string())
             .env("GIT_COMMITTER_DATE", committer.epoch_time_string())
             .stdin(Stdio::piped())
@@ -554,7 +554,7 @@ impl<'repo, 'index> StupidContext<'repo, 'index> {
             .map(|output| DiffFiles::new(output.stdout))
     }
 
-    /// Interative diff-tree (for 'stg files').
+    /// Interactive diff-tree (for 'stg files').
     pub(crate) fn diff_tree_files_status(
         &self,
         tree1: git2::Oid,
@@ -879,7 +879,7 @@ impl<'repo, 'index> StupidContext<'repo, 'index> {
         }
     }
 
-    /// Perfom three-way merge, with optional auto-resolution of conflicts with `git merge-tool`.
+    /// Perform three-way merge, with optional auto-resolution of conflicts with `git merge-tool`.
     pub(crate) fn merge_recursive_or_mergetool(
         &self,
         base_tree_id: git2::Oid,


### PR DESCRIPTION
Found via `codespell -S t -L crate,isnt,toke,swith`