### PR TITLE
Add shorthand -s for --signoff for the edit command

### DIFF
--- a/src/patchedit/mod.rs
+++ b/src/patchedit/mod.rs
@@ -128,6 +128,7 @@ pub(crate) fn add_args(
         .arg(
             Arg::new("signoff")
                 .long("signoff")
+                .short('s')
                 .alias("sign")
                 .help("Add Signed-off-by message trailer")
                 .long_help(


### PR DESCRIPTION
Stgit's email format command and git-commit(1) already support this shorthand.

Signed-off-by: Wei Liu <liuw@liuw.name>