### PR TITLE
chore: update gix-revision, fixes #306

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12fc4bbc3161a5b2d68079fce93432cef8771ff88ca017abb01187fddfc41a1"
+checksum = "3c6f6ff53f888858afc24bf12628446a14279ceec148df6194481f306f553ad2"
 dependencies = [
  "bstr",
  "gix-date",


### PR DESCRIPTION
Fixes https://github.com/stacked-git/stgit/issues/306

The underlying cause of the error reported in the linked issue was a bug in `gitoxide` which got fixed in the latest release.