### PR TITLE
fix(import): Keep first line break in body

### DIFF
--- a/src/cmd/import.rs
+++ b/src/cmd/import.rs
@@ -913,6 +913,7 @@ impl Headers {
 
             if headers.subject.is_some() {
                 split_message.push_str(line.strip_prefix(dedent.as_bytes()).unwrap_or(line));
+                split_message.push_char('\n');
                 break;
             }
 

--- a/t/t1800-import.sh
+++ b/t/t1800-import.sh
@@ -19,7 +19,8 @@ test_expect_success 'Import patch with email headers' '
 	Subject: Hey: the subject
 	Message-ID: abc123
 
-	body
+	body1
+	body2
 
 	---
 
@@ -41,7 +42,8 @@ test_expect_success 'Import patch with email headers' '
     test_when_finished "rm subject body expected" &&
     test_cmp expected subject &&
     cat >expected <<-\EOF &&
-	body
+	body1
+	body2
 
 	Message-ID: abc123
 
@@ -58,7 +60,8 @@ test_expect_success 'Import patch without email headers' '
     cat >patch <<-\EOF &&
 	test subject
 
-	body
+	body1
+	body2
 
 	---
 
@@ -80,7 +83,9 @@ test_expect_success 'Import patch without email headers' '
     test_when_finished "rm subject body expected" &&
     test_cmp expected subject &&
     cat >expected <<-\EOF &&
-	body
+	body1
+	body2
+
 
 	EOF
     test_cmp expected body &&
@@ -95,7 +100,8 @@ test_expect_success 'Patch subject resemebles header' '
     cat >patch <<-\EOF &&
 	test: subject
 
-	body
+	body1
+	body2
 
 	---
 
@@ -117,7 +123,9 @@ test_expect_success 'Patch subject resemebles header' '
     test_when_finished "rm subject body expected" &&
     test_cmp expected subject &&
     cat >expected <<-\EOF &&
-	body
+	body1
+	body2
+
 
 	EOF
     test_cmp expected body &&


### PR DESCRIPTION
When importing a patch with multiple lines, the first line break in the body was removed from the body of the commit in the stack, because it was stripped when searching for the headers. Add the line break again when adding the first line to the split_message.

This did not surface in the tests, because the test bodies always had one line and the expected bodies had an incorrect number of line breaks at the end. Fix the expected number of line breaks as well.