### PR TITLE
Fix year in changelog (2024 -> 2023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.4.2 2024-12-26
+## 2.4.2 2023-12-26
 
 ### Changed
 - feat(pop): allow unescaped negative patch offsets
@@ -8,7 +8,7 @@
 - chore: update dependencies
 
 
-## 2.4.1 2024-12-10
+## 2.4.1 2023-12-10
 
 ### Fixed
 - fix(zsh): short -r opt for `stg series`
@@ -18,7 +18,7 @@
 - chore: update transient dependencies
 
 
-## 2.4.0 2024-10-08
+## 2.4.0 2023-10-08
 
 ### Added
 - feat(delete): --all -A -U -H options


### PR DESCRIPTION
While reading the changelog on the website I noticed the latest entry in the changelog says `2024-10-08`. Presumably this was a typo that was copy-pasted for the more recent entries? If you are actually from the future, feel free to close the PR 😉 