### PR TITLE
fix: Pass stdio for interactive editing

### DIFF
--- a/src/patch/edit/interactive.rs
+++ b/src/patch/edit/interactive.rs
@@ -92,6 +92,7 @@ pub(crate) fn call_editor<P: AsRef<Path>>(
         let status_result = gix_command::prepare(&editor)
             .arg(path.as_ref())
             .with_shell_allow_argument_splitting()
+            .stdin(std::process::Stdio::inherit())
             .stdout(std::process::Stdio::inherit())
             .spawn()
             .with_context(|| format!("running editor: {}", editor.to_string_lossy()))


### PR DESCRIPTION
gix_command by default does not pass stdin to commands. This caused editors and shells to behave weirdly. For example, vim printed a warning during opening:

Vim: Warning: Input is not from a terminal

After closing vim started this way, the terminal was messed up and needed an reset to print outputs correctly.

This is an attempt to fix stacked-git/stgit#415. It fixes the issue described there, but I can not say how it will affect other editors or even scripts. It may re-introduce some errors that 048f182a ("fix: use gix-command for interactive edit") originally tried to fix.

Closes #415 