### PR TITLE
fix: harden "stg rebase -i" against patches with milti-line subjects

### DIFF
--- a/src/cmd/rebase.rs
+++ b/src/cmd/rebase.rs
@@ -497,7 +497,10 @@ fn make_instructions_template(stack: &Stack, previously_applied: &[PatchName]) -
         let subject = commit
             .message()
             .map(|message_ref| message_ref.title.to_str_lossy())
-            .unwrap_or_default();
+            .unwrap_or_default()
+            .replace(['\r', '\n'], " ")
+            .trim()
+            .to_owned();
         writeln!(template, "keep {patchname:name_width$} # {subject}").unwrap();
     }
     if !found_apply_boundary {

--- a/t/t2203-rebase-interactive.sh
+++ b/t/t2203-rebase-interactive.sh
@@ -277,4 +277,13 @@ test_expect_success 'No patches exits early' '
     stg rebase --interactive
 '
 
+test_expect_success 'Patches with multi-line subject' '
+    printf "p0: line 1\nline 2\n" | stg new -f - p0 &&
+    printf "p1: line 1\nline 2\n" | stg new -f - p1 &&
+    test_set_editor cat &&
+    test_when_finished test_set_editor false &&
+    stg rebase --interactive &&
+    test "$(stg series --applied -c)" = "2"
+'
+
 test_done


### PR DESCRIPTION
I have a stgit stack that is very old (I started it more than 10 years ago), so it has all kinds of WIP patches that I started and then did not quite finish. In several of them I have malformed patch subjects, such as multi-line titles:

$ git show -1 --pretty=%B
subsystem: fix driver
certain change

This breaks "stg rebase -i" because it expects to have one line per patch in the rebase template, but in this case subject spills over to the next line which rebase mistakes for an instruction:

error: unknown instruction action `certain`

Fix this my replacing new lines and line feeds in the subject with spaces.