### PR TITLE
fix: stg import --reject should create empty commit

### DIFF
--- a/t/t1800-import.sh
+++ b/t/t1800-import.sh
@@ -366,6 +366,16 @@ test_expect_success 'Import series from stdin' '
     stg delete --top
 '
 
+test_expect_success 'Import patch that does not apply cleanly with --reject' '
+    conflict stg import --reject "$TEST_DIRECTORY"/t1800/diff-with-rejects 2>err &&
+    git log -1 --pretty=format:%b >body &&
+    test_when_finished "rm foo.txt.rej err body" &&
+    test "$(echo $(stg top))" = "diff-with-rejects" &&
+    test_line_count = 0 body &&
+    stg reset --hard &&
+    stg delete --top
+'
+
 test_expect_success STG_IMPORT_URL 'Attempt url' '
     general_error stg import --url 2>err &&
     grep -e "required arguments were not provided" err

--- a/t/t1800/diff-with-rejects
+++ b/t/t1800/diff-with-rejects
@@ -1,0 +1,29 @@
+test patch with rejects
+
+---
+
+ t/t1800/foo.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/t/t1800/foo.txt b/t/t1800/foo.txt
+index ad01662f..d609de80 100644
+--- a/foo.txt
++++ b/foo.txt
+@@ -6,7 +6,7 @@ dobidim
+ dobidum
+ dobodam
+ dobodim
+-dobodum
++dObodum
+ dibedam
+ dibedim
+ dibedum
+@@ -18,7 +18,7 @@ dibodim
+ dibodum
+ dabedam
+ dabedim
+-Dabedum
++dAbedum
+ dabidam
+ dabidim
+ dabidum

--- a/t/t3600-fold.sh
+++ b/t/t3600-fold.sh
@@ -91,7 +91,7 @@ test_expect_success 'Attempt to fold conflicting patch with rejects' '
     echo "hello" >foo.txt &&
     echo "from p2" >>foo.txt &&
     stg refresh &&
-    command_error stg fold --reject fold1.diff 2>err &&
+    conflict stg fold --reject fold1.diff 2>err &&
     grep "patch failed" err &&
     test -z "$(echo $(stg status --porcelain foo.txt))" &&
     test -e foo.txt.rej &&


### PR DESCRIPTION
When trying to import a patch that does not apply cleanly, and using --reject option, stg should apply what it can, leave the rest in .rej files, and create an empty commit. The work to apply the patch is outsourced to "git apply --reject" which exits with status code 1 if patch is applied partially and it is treated as error by stg import.

Fix the issue by not treating return code of 1 from "git apply" as an error when "--reject" option is specified, but rather saving its output, printing it for the user, and continuing with the rest of the import logic. Exit with CONFLICT_ERROR rather than COMMAND_ERROR when the patch does not import/apply cleanly.

"stg fold" reuses much of the same code so it has to be adjusted in the similar fashion. It will also exit with CONFLICT_ERROR when a patch does not apply cleanly.

Also add a test case and fix up documentation for "stg import" and adjust test case for "stg fold".

Closes: #471