### PR TITLE
support calling stg rebase without arguments

### DIFF
--- a/t/t2200-rebase.sh
+++ b/t/t2200-rebase.sh
@@ -43,4 +43,9 @@ test_expect_success 'Rebase to same base message' '
     grep "info: Already based on .*(master)" out
 '
 
+test_expect_success 'Rebase without argument' '
+    test_must_fail stg rebase 2>out &&
+    grep -q "error: the following required arguments were not provided" out
+'
+
 test_done

--- a/t/t2200-rebase.sh
+++ b/t/t2200-rebase.sh
@@ -45,7 +45,20 @@ test_expect_success 'Rebase to same base message' '
 
 test_expect_success 'Rebase without argument' '
     test_must_fail stg rebase 2>out &&
-    grep -q "error: the following required arguments were not provided" out
+    grep -q "error: there is no tracking information for the current branch" out &&
+    git checkout master &&
+    echo bar >>file2 &&
+    git add file2 &&
+    git commit -m c &&
+    git remote add origin "file://$(pwd)" &&
+    git fetch origin &&
+    git checkout stack &&
+    git branch --set-upstream-to=origin/master &&
+    stg rebase 2>out &&
+    grep "info: Rebasing to .*(master origin/master)" out &&
+    test $(stg series --applied -c) = 1 &&
+    grep bar file1 &&
+    grep bar file2
 '
 
 test_done

--- a/t/test-lib-functions.sh
+++ b/t/test-lib-functions.sh
@@ -1024,7 +1024,7 @@ test_must_fail_acceptable () {
 	fi
 
 	case "$1" in
-	git|__git*|scalar|test-tool|fake_tool|test_terminal)
+	git|__git*|scalar|test-tool|fake_tool|test_terminal|stg)
 		return 0
 		;;
 	*)


### PR DESCRIPTION
When calling "git rebase" without a target commit argument then it will try to look up remote tracking branch and rebase onto that. This change makes "stg rebase" behave the same way. Note that this introduces a slight discrepancy with "stg rebase --interactive": in this case it will still use the stack base instead of the remote tracking branch.