### PR TITLE
feat: organize subcommands by group in help

### DIFF
--- a/src/cmd/completion/list.rs
+++ b/src/cmd/completion/list.rs
@@ -181,6 +181,9 @@ fn list_commands(output: &mut Box<dyn std::io::Write>, style: OutputStyle) -> Re
                              ~~~~~~~~~~~~~~\n"
                         )?;
                     }
+                    CommandCategory::Alias | CommandCategory::Help => {
+                        unreachable!();
+                    }
                 }
                 last_category = Some(category);
             }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -59,6 +59,8 @@ pub(crate) enum CommandCategory {
     StackInspection,
     StackManipulation,
     Administration,
+    Alias,
+    Help,
 }
 
 /// Entry point for a StGit subcommand.


### PR DESCRIPTION
The list of subcommands is getting rather long. Combined with aliases they create a wall of text in the help message that is hard to scan. We can break up the long list into multiple smallers by grouping commands by category. This creates a more meaningful help message.

#### Before
```
   Compiling stgit v2.4.13 (/Users/frank/Projects/stgit)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.82s
     Running `target/debug/stg`
Maintain a stack of patches on top of a Git branch.

Usage: stg [OPTIONS] <command> [...]
       stg [OPTIONS] <-h|--help>
       stg --version

Commands:
  branch      Branch operations: switch, list, create, rename, delete, ...
  clean       Delete empty patches from the series
  commit      Finalize patches to the stack base
  completion  Support for shell completions
  delete      Delete patches
  diff        Show a diff
  edit        Edit a patch
  email       Format and send patches as email
  export      Export patches to a directory
  files       Show files modified by a patch
  float       Push patches to the top, even if applied
  fold        Fold diff file into the current patch
  goto        Go to patch by pushing or popping as necessary
  hide        Hide patches in the series
  id          Print git hash of a StGit revision
  import      Import patches to stack
  init        Initialize a StGit stack on a branch
  log         Display or optionally clear the stack changelog
  new         Create a new patch at top of the stack
  next        Print the name of the next patch
  patches     Show patches that modify files
  pick        Import a patch from another branch or a commit object
  pop         Pop (unapply) one or more applied patches
  prev        Print the name of the previous patch
  pull        Pull changes from a remote repository
  push        Push (apply) one or more unapplied patches
  rebase      Move the stack base to another point in history
  redo        Undo the last undo operation
  refresh     Incorporate worktree changes into current patch
  rename      Rename a patch
  repair      Repair stack after branch is modified with git commands
  reset       Reset the patch stack to an earlier state
  series      Display the patch series
  show        Show patch commits
  sink        Move patches deeper in the stack
  spill       Spill changes from the topmost patch
  squash      Squash two or more patches into one
  sync        Synchronize patches with a branch or a series
  top         Print the name of the top patch
  uncommit    Convert regular Git commits into StGit patches
  undo        Undo the last command
  unhide      Unhide hidden patches
  version     Print version information and exit
  add         Alias for shell command `git -C "$GIT_PREFIX" add`
  bottom      Alias for `stg goto 0`
  ll          Alias for `stg series -eId`
  lli         Alias for `stg series -Id --commit-id=8`
  ls          Alias for `stg series -e`
  mv          Alias for shell command `git -C "$GIT_PREFIX" mv`
  resolved    Alias for shell command `git -C "$GIT_PREFIX" add`
  rm          Alias for shell command `git -C "$GIT_PREFIX" rm`
  status      Alias for shell command `git status -s`
  help        Print this message or the help of the given subcommand(s)

Options:
      --version       Print version information
  -C <path>           Run as if started in <path>
      --color <when>  When to colorize output: auto, always, ansi, never
  -h, --help          Print help (see more with '--help')
```

#### After
```
   Compiling stgit v2.4.13 (/Users/frank/Projects/stgit)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.23s
     Running `target/debug/stg`
Maintain a stack of patches on top of a Git branch.

Usage: stg [OPTIONS] <command> [...]
       stg [OPTIONS] <-h|--help>
       stg --version

Patch inspection commands:
  diff   Show a diff
  files  Show files modified by a patch
  id     Print git hash of a StGit revision
  log    Display or optionally clear the stack changelog
  show   Show patch commits

Patch manipulation commands:
  edit     Edit a patch
  fold     Fold diff file into the current patch
  new      Create a new patch at top of the stack
  refresh  Incorporate worktree changes into current patch
  rename   Rename a patch
  spill    Spill changes from the topmost patch
  sync     Synchronize patches with a branch or a series

Stack inspection commands:
  email    Format and send patches as email
  export   Export patches to a directory
  next     Print the name of the next patch
  patches  Show patches that modify files
  prev     Print the name of the previous patch
  series   Display the patch series
  top      Print the name of the top patch

Stack manipulation commands:
  branch    Branch operations: switch, list, create, rename, delete, ...
  clean     Delete empty patches from the series
  commit    Finalize patches to the stack base
  delete    Delete patches
  float     Push patches to the top, even if applied
  goto      Go to patch by pushing or popping as necessary
  hide      Hide patches in the series
  import    Import patches to stack
  init      Initialize a StGit stack on a branch
  pick      Import a patch from another branch or a commit object
  pop       Pop (unapply) one or more applied patches
  pull      Pull changes from a remote repository
  push      Push (apply) one or more unapplied patches
  rebase    Move the stack base to another point in history
  redo      Undo the last undo operation
  repair    Repair stack after branch is modified with git commands
  reset     Reset the patch stack to an earlier state
  sink      Move patches deeper in the stack
  squash    Squash two or more patches into one
  uncommit  Convert regular Git commits into StGit patches
  undo      Undo the last command
  unhide    Unhide hidden patches

Administration commands:
  completion  Support for shell completions
  version     Print version information and exit

Aliases:
  add       Alias for shell command `git -C "$GIT_PREFIX" add`
  bottom    Alias for `stg goto 0`
  ll        Alias for `stg series -eId`
  lli       Alias for `stg series -Id --commit-id=8`
  ls        Alias for `stg series -e`
  mv        Alias for shell command `git -C "$GIT_PREFIX" mv`
  resolved  Alias for shell command `git -C "$GIT_PREFIX" add`
  rm        Alias for shell command `git -C "$GIT_PREFIX" rm`
  status    Alias for shell command `git status -s`

Help:
  help  Print this message or the help of the given subcommand(s)

Options:
      --version       Print version information
  -C <path>           Run as if started in <path>
      --color <when>  When to colorize output: auto, always, ansi, never
  -h, --help          Print help (see more with '--help')

```