### PR TITLE
docs: explain stgit.autosign a bit better

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,9 @@ following guidelines:
   certifies that you wrote or otherwise have the right to contribute the
   patch as open-source, according to the [Developers Certificate of
   Origin](#developers-certificate-of-origin-11). A `Signed-off-by:` line
-  can be added to a patch by running `stg edit --sign`.
+  can be added to a patch by running `stg edit --sign`, and you can add one to
+  new patches by default with the setting by setting the config
+  `stgit.autosign` to `Signed-off-by`.
   
 - Lint. Run `make lint` to ensure that the code meets the project's
   syntactic standards and passes static checks.

--- a/Documentation/stg.txt
+++ b/Documentation/stg.txt
@@ -265,8 +265,10 @@ stgit.autoimerge::
   is automatically run to attempt to resolve the conflicts.
 
 stgit.autosign::
-  Automatically add "Signed-off-by:" trailer to commit messages for new patches created
-  with linkstg:new[] or lingstg:import[].
+  Automatically add signoff trailer to commit messages for new patches created
+  with linkstg:new[] or lingstg:import[]. The value of this configuration
+  variable will be used as the key of the trailer and therefore should be set
+  to something like 'Signed-off-by'.
 
 stgit.autostash::
   When running linkstg:rebase[], if any modified files are found in the working tree, a


### PR DESCRIPTION
After reading the documentation to `stgit.autosign` I set it to `true` and got a trailer like `true: My Name <my@email.net>` which wasn't what I expected. I reworded the documentation slightly which hopefully clarifies it a bit. I also added a hint to `CONTRIBUTING.md` which I hope is the right thing.