### PR TITLE
ci: use ubuntu-24.04 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -104,10 +104,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             profile: dev
             toolchain: stable
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             profile: dev
             toolchain: nightly
           - os: macos-latest
@@ -125,7 +125,7 @@ jobs:
         run: |
           cargo --locked build --profile ${{ matrix.profile }}
       - name: Install Test Dependencies
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
         run: |
           sudo apt-get update
           sudo apt-get install quilt gnupg2 libio-pty-perl
@@ -152,7 +152,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -166,7 +166,7 @@ jobs:
 
   clippy:
     name: Clippy Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -181,7 +181,7 @@ jobs:
 
   rustfmt:
     name: Format Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -196,7 +196,7 @@ jobs:
 
   api-docs:
     name: API Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -272,7 +272,7 @@ jobs:
   github-release:
     name: GitHub Release
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [release, windows-build]
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Explicitly move to ubuntu-24.04 images, which will soon become ubuntu-latest for github actions.

Ref: https://github.com/actions/runner-images/issues/10636
Ref: https://github.com/actions/runner-images/blob/main/README.md