### PR TITLE
build: statically linked packages for riscv64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          targets: i686-unknown-linux-musl,x86_64-unknown-linux-musl,aarch64-unknown-linux-musl
+          targets: i686-unknown-linux-musl,x86_64-unknown-linux-musl,aarch64-unknown-linux-musl,riscv64gc-unknown-linux-musl
           components: clippy, rustfmt
       - name: Build
         run: |
@@ -70,9 +70,9 @@ jobs:
         with:
           crate: cargo-generate-rpm
           version: "^0.15.0"
-      - name: Install aarch64 Dependencies
+      - name: Install aarch64 and riscv64 Dependencies
         run: |
-          sudo apt-get install gcc-aarch64-linux-gnu
+          sudo apt-get install gcc-aarch64-linux-gnu gcc-riscv64-linux-gnu
       - name: Static Build x86_64
         run: |
           make build-static-x86_64
@@ -85,11 +85,19 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_STRIP: "aarch64-linux-gnu-strip"
         run: |
           make build-static-aarch64
+      - name: Static Build riscv64
+        env:
+          CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_LINKER: "riscv64-linux-gnu-gcc"
+          CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_STRIP: "riscv64-linux-gnu-strip"
+        run: |
+          make build-static-riscv64
       - name: Build Packages
         env:
           USE_ASCIIDOCTOR: "1"
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: "aarch64-linux-gnu-gcc"
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_STRIP: "aarch64-linux-gnu-strip"
+          CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_LINKER: "riscv64-linux-gnu-gcc"
+          CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_STRIP: "riscv64-linux-gnu-strip"
         run: |
           make packages
       - name: Upload Packages

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,9 +94,11 @@ The following Makefile targets are available to build packages:
 - `deb-i686`: build `stgit_x.y.z_i386.deb`
 - `deb-x86_64`: build `stgit_x.y.z_amd64.deb`
 - `deb-aarch64`: build `stgit_x.y.z_arm64.deb`
+- `deb-riscv64`: build `stgit_x.y.z_riscv64.deb`
 - `rpm-i686`: build `stgit-x.y.z-w.i686.rpm`
 - `rpm-x86_64`: build `stgit-x.y.z-w.x86_64.rpm`
 - `rpm-aarch64`: build `stgit-x.y.z-w.aarch64.rpm`
+- `rpm-riscv64`: build `stgit-x.y.z-w.riscv64.rpm`
 
 The generated package files are output to `target/pkg/`.
 
@@ -106,6 +108,7 @@ Rust Dependencies
 To build these packages, rust needs to be setup for some additional targets:
 
 - aarch64-unknown-linux-musl
+- riscv64gc-unknown-linux-musl
 - i686-unknown-linux-musl
 - x86_64-unknown-linux-musl
 
@@ -121,19 +124,22 @@ install`.
 Linker Setup
 ============
 
-When cross-compiling, e.g. when building aarch64 targets from an x86_64
-host, the cross compiler linker needs to be installed and configured.
+When cross-compiling, e.g. when building aarch64 or riscv64 targets from
+an x86_64 host, the cross compiler linker needs to be installed and configured.
 
-On Arch Linux, install `aarch64-linux-gnu-gcc`.
+On Arch Linux, install `aarch64-linux-gnu-gcc` and `riscv64-linux-gnu-gcc`.
 
 In Debian/Ubuntu environments, install the `gcc-aarch64-linux-gnu`
-package.
+and `gcc-riscv64-linux-gnu` packages.
 
 To configure, add the following to your `~/.cargo/config.toml` file:
 
 ```toml
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-gnu-gcc"
+
+[target.riscv64gc-unknown-linux-musl]
+linker = "riscv64-linux-gnu-gcc"
 ```
 
 [musl]: https://musl.libc.org/

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ build-static-x86_64:
 build-static-aarch64:
 	$(CARGO) build --profile=for-pkg --target aarch64-unknown-linux-musl --no-default-features
 
+build-static-riscv64:
+	$(CARGO) build --profile=for-pkg --target riscv64gc-unknown-linux-musl --no-default-features
+
 target/pkg:
 	mkdir -p $@
 
@@ -78,7 +81,10 @@ deb-x86_64: completion doc target/pkg build-static-x86_64
 deb-aarch64: completion doc target/pkg build-static-aarch64
 	$(CARGO_OFFLINE) deb --no-build --no-strip --output target/pkg/ --profile=for-pkg --target=aarch64-unknown-linux-musl
 
-debs: deb-i686 deb-x86_64 deb-aarch64
+deb-riscv64: completion doc target/pkg build-static-riscv64
+	$(CARGO_OFFLINE) deb --no-build --no-strip --output target/pkg/ --profile=for-pkg --target=riscv64gc-unknown-linux-musl
+
+debs: deb-i686 deb-x86_64 deb-aarch64 deb-riscv64
 
 rpm-i686: completion doc target/pkg build-static-i686
 	$(CARGO_OFFLINE) generate-rpm --output target/pkg/ --profile=for-pkg --target=i686-unknown-linux-musl
@@ -89,14 +95,17 @@ rpm-x86_64: completion doc target/pkg build-static-x86_64
 rpm-aarch64: completion doc target/pkg build-static-aarch64
 	$(CARGO_OFFLINE) generate-rpm --output target/pkg/ --profile=for-pkg --target=aarch64-unknown-linux-musl
 
-rpms: rpm-i686 rpm-x86_64 rpm-aarch64
+rpm-riscv64: completion doc target/pkg build-static-riscv64
+	$(CARGO_OFFLINE) generate-rpm --output target/pkg/ --profile=for-pkg --target=riscv64gc-unknown-linux-musl
+
+rpms: rpm-i686 rpm-x86_64 rpm-aarch64 rpm-riscv64
 
 packages: debs rpms
 
 .PHONY: packages
-.PHONY: debs deb-i686 deb-x86_64 deb-aarch64
-.PHONY: rpms rpm-i686 rpm-x86_64 rpm-aarch64
-.PHONY: build-static-i686 build-static-x86_64 build-static-aarch64
+.PHONY: debs deb-i686 deb-x86_64 deb-aarch64 deb-riscv64
+.PHONY: rpms rpm-i686 rpm-x86_64 rpm-aarch64 rpm-riscv64
+.PHONY: build-static-i686 build-static-x86_64 build-static-aarch64 build-static-riscv64
 
 
 lint: lint-format lint-clippy lint-api-doc lint-t unit-test


### PR DESCRIPTION
Now that the riscv64gc musl target is promoted to tier2 and everything is in place, let's build for riscv64
Debian package tested on real HW.