### PR TITLE
chore: update gix to 0.73

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,18 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,15 +307,6 @@ dependencies = [
 
 [[package]]
 name = "faster-hex"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "faster-hex"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
@@ -361,6 +340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -369,6 +349,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -403,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.71.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61e71ec6817fc3c9f12f812682cfe51ee6ea0d2e27e02fc3849c35524617435"
+checksum = "514c29cc879bdc0286b0cbc205585a49b252809eb86c69df4ce4f855ee75f635"
 dependencies = [
  "gix-actor",
  "gix-command",
@@ -414,10 +400,10 @@ dependencies = [
  "gix-date",
  "gix-diff",
  "gix-discover",
- "gix-features 0.41.1",
- "gix-fs 0.14.0",
+ "gix-features",
+ "gix-fs",
  "gix-glob",
- "gix-hash 0.17.0",
+ "gix-hash",
  "gix-hashtable",
  "gix-index",
  "gix-lock",
@@ -436,8 +422,8 @@ dependencies = [
  "gix-trace",
  "gix-traverse",
  "gix-url",
- "gix-utils 0.2.0",
- "gix-validate 0.9.4",
+ "gix-utils",
+ "gix-validate",
  "once_cell",
  "smallvec",
  "thiserror",
@@ -445,13 +431,13 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.34.0"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f438c87d4028aca4b82f82ba8d8ab1569823cfb3e5bc5fa8456a71678b2a20e7"
+checksum = "58ebbb8f41071c7cf318a0b1db667c34e1df49db7bf387d282a4e61a3b97882c"
 dependencies = [
  "bstr",
  "gix-date",
- "gix-utils 0.2.0",
+ "gix-utils",
  "itoa",
  "thiserror",
  "winnow",
@@ -477,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "gix-command"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0378995847773a697f8e157fe2963ecf3462fe64be05b7b3da000b3b472def8"
+checksum = "6b31b65ca48a352ae86312b27a514a0c661935f96b481ac8b4371f65815eb196"
 dependencies = [
  "bstr",
  "gix-path",
@@ -490,26 +476,26 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043cbe49b7a7505150db975f3cb7c15833335ac1e26781f615454d9d640a28fe"
+checksum = "6bb23121e952f43a5b07e3e80890336cb847297467a410475036242732980d06"
 dependencies = [
  "bstr",
  "gix-chunk",
- "gix-hash 0.17.0",
+ "gix-hash",
  "memmap2",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-config"
-version = "0.44.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6f830bf746604940261b49abf7f655d2c19cadc9f4142ae9379e3a316e8cfa"
+checksum = "5dfb898c5b695fd4acfc3c0ab638525a65545d47706064dcf7b5ead6cdb136c0"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.41.1",
+ "gix-features",
  "gix-glob",
  "gix-path",
  "gix-ref",
@@ -524,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.14.12"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc2c844c4cf141884678cabef736fd91dd73068b9146e6f004ba1a0457944b6"
+checksum = "9f012703eb67e263c6c1fc96649fec47694dd3e5d2a91abfc65e4a6a6dc85309"
 dependencies = [
  "bitflags",
  "bstr",
@@ -537,38 +523,39 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.9.4"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa30058ec7d3511fbc229e4f9e696a35abd07ec5b82e635eff864a2726217e4"
+checksum = "d7235bdf4d9d54a6901928e3a37f91c16f419e6957f520ed929c3d292b84226e"
 dependencies = [
  "bstr",
  "itoa",
  "jiff",
+ "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-diff"
-version = "0.51.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c975dad2afc85e4e233f444d1efbe436c3cdcf3a07173984509c436d00a3f8"
+checksum = "de854852010d44a317f30c92d67a983e691c9478c8a3fb4117c1f48626bcdea8"
 dependencies = [
  "bstr",
- "gix-hash 0.17.0",
+ "gix-hash",
  "gix-object",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-discover"
-version = "0.39.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fb8a4349b854506a3915de18d3341e5f1daa6b489c8affc9ca0d69efe86781"
+checksum = "ffb180c91ca1a2cf53e828bb63d8d8f8fa7526f49b83b33d7f46cbeb5d79d30a"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs 0.14.0",
- "gix-hash 0.17.0",
+ "gix-fs",
+ "gix-hash",
  "gix-path",
  "gix-ref",
  "gix-sec",
@@ -577,15 +564,15 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.41.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016d6050219458d14520fe22bdfdeb9cb71631dec9bc2724767c983f60109634"
+checksum = "9a92748623c201568785ee69a561f4eec06f745b4fac67dab1d44ca9891a57ee"
 dependencies = [
  "crc32fast",
  "flate2",
  "gix-path",
  "gix-trace",
- "gix-utils 0.2.0",
+ "gix-utils",
  "libc",
  "once_cell",
  "prodash",
@@ -594,146 +581,108 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-features"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f4399af6ec4fd9db84dd4cf9656c5c785ab492ab40a7c27ea92b4241923fed"
-dependencies = [
- "gix-trace",
- "gix-utils 0.3.0",
- "libc",
- "prodash",
-]
-
-[[package]]
 name = "gix-fs"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951e886120dc5fa8cac053e5e5c89443f12368ca36811b2e43d1539081f9c111"
+checksum = "d793f71e955d18f228d20ec433dcce6d0e8577efcdfd11d72d09d7cc2758dfd1"
 dependencies = [
  "bstr",
  "fastrand",
- "gix-features 0.41.1",
+ "gix-features",
  "gix-path",
- "gix-utils 0.2.0",
- "thiserror",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a0637149b4ef24d3ea55f81f77231401c8463fae6da27331c987957eb597c7"
-dependencies = [
- "bstr",
- "fastrand",
- "gix-features 0.42.1",
- "gix-path",
- "gix-utils 0.3.0",
+ "gix-utils",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20972499c03473e773a2099e5fd0c695b9b72465837797a51a43391a1635a030"
+checksum = "b947db8366823e7a750c254f6bb29e27e17f27e457bf336ba79b32423db62cd5"
 dependencies = [
  "bitflags",
  "bstr",
- "gix-features 0.41.1",
+ "gix-features",
  "gix-path",
 ]
 
 [[package]]
 name = "gix-hash"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834e79722063958b03342edaa1e17595cd2939bb2b3306b3225d0815566dcb49"
+checksum = "251fad79796a731a2a7664d9ea95ee29a9e99474de2769e152238d4fdb69d50e"
 dependencies = [
- "faster-hex 0.9.0",
- "gix-features 0.41.1",
- "sha1-checked",
- "thiserror",
-]
-
-[[package]]
-name = "gix-hash"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4900562c662852a6b42e2ef03442eccebf24f047d8eab4f23bc12ef0d785d8"
-dependencies = [
- "faster-hex 0.10.0",
- "gix-features 0.42.1",
+ "faster-hex",
+ "gix-features",
  "sha1-checked",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-hashtable"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b5cb3c308b4144f2612ff64e32130e641279fcf1a84d8d40dad843b4f64904"
+checksum = "c35300b54896153e55d53f4180460931ccd69b7e8d2f6b9d6401122cdedc4f07"
 dependencies = [
- "gix-hash 0.18.0",
- "hashbrown 0.14.5",
+ "gix-hash",
+ "hashbrown",
  "parking_lot",
 ]
 
 [[package]]
 name = "gix-index"
-version = "0.39.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855bece2d4153453aa5d0a80d51deea1ce8cd6a3b4cf213da85ac344ccb908a7"
+checksum = "2af39fde3ce4ce11371d9ce826f2936ec347318f2d1972fe98c2e7134e267e25"
 dependencies = [
  "bitflags",
  "bstr",
  "filetime",
  "fnv",
  "gix-bitmap",
- "gix-features 0.41.1",
- "gix-fs 0.14.0",
- "gix-hash 0.17.0",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
  "gix-lock",
  "gix-object",
  "gix-traverse",
- "gix-utils 0.2.0",
- "gix-validate 0.9.4",
- "hashbrown 0.14.5",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown",
  "itoa",
  "libc",
  "memmap2",
- "rustix 0.38.44",
+ "rustix",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-lock"
-version = "17.1.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570f8b034659f256366dc90f1a24924902f20acccd6a15be96d44d1269e7a796"
+checksum = "b9fa71da90365668a621e184eb5b979904471af1b3b09b943a84bc50e8ad42ed"
 dependencies = [
  "gix-tempfile",
- "gix-utils 0.3.0",
+ "gix-utils",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-object"
-version = "0.48.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4943fcdae6ffc135920c9ea71e0362ed539182924ab7a85dd9dac8d89b0dd69a"
+checksum = "49664e3e212bc34f7060f5738ce7022247e4afd959b68a4f666b1fd29c00b23c"
 dependencies = [
  "bstr",
  "gix-actor",
  "gix-date",
- "gix-features 0.41.1",
- "gix-hash 0.17.0",
+ "gix-features",
+ "gix-hash",
  "gix-hashtable",
  "gix-path",
- "gix-utils 0.2.0",
- "gix-validate 0.9.4",
+ "gix-utils",
+ "gix-validate",
  "itoa",
  "smallvec",
  "thiserror",
@@ -742,15 +691,15 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.68.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50306d40dcc982eb6b7593103f066ea6289c7b094cb9db14f3cd2be0b9f5e610"
+checksum = "9c9d7af10fda9df0bb4f7f9bd507963560b3c66cb15a5b825caf752e0eb109ac"
 dependencies = [
  "arc-swap",
  "gix-date",
- "gix-features 0.41.1",
- "gix-fs 0.14.0",
- "gix-hash 0.17.0",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
  "gix-hashtable",
  "gix-object",
  "gix-pack",
@@ -763,14 +712,14 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.58.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b65fffb09393c26624ca408d32cfe8776fb94cd0a5cdf984905e1d2f39779cb"
+checksum = "d8571df89bfca5abb49c3e3372393f7af7e6f8b8dbe2b96303593cef5b263019"
 dependencies = [
  "clru",
  "gix-chunk",
- "gix-features 0.41.1",
- "gix-hash 0.17.0",
+ "gix-features",
+ "gix-hash",
  "gix-hashtable",
  "gix-object",
  "gix-path",
@@ -781,25 +730,25 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.18.4"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123844a70cf4d5352441dc06bab0da8aef61be94ec239cb631e0ba01dc6d3a04"
+checksum = "2592fbd36249a2fea11056f7055cc376301ef38d903d157de41998335bbf1f93"
 dependencies = [
  "bstr",
- "faster-hex 0.9.0",
+ "faster-hex",
  "gix-trace",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-path"
-version = "0.10.18"
+version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567f65fec4ef10dfab97ae71f26a27fd4d7fe7b8e3f90c8a58551c41ff3fb65b"
+checksum = "c6279d323d925ad4790602105ae27df4b915e7a7d81e4cdba2603121c03ad111"
 dependencies = [
  "bstr",
  "gix-trace",
- "gix-validate 0.10.0",
+ "gix-validate",
  "home",
  "once_cell",
  "thiserror",
@@ -807,18 +756,18 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5678ddae1d62880bc30e2200be1b9387af3372e0e88e21f81b4e7f8367355b5a"
+checksum = "12b4b807c47ffcf7c1e5b8119585368a56449f3493da93b931e1d4239364e922"
 dependencies = [
  "bstr",
  "gix-date",
- "gix-features 0.41.1",
- "gix-hash 0.17.0",
+ "gix-features",
+ "gix-hash",
  "gix-ref",
  "gix-shallow",
  "gix-transport",
- "gix-utils 0.2.0",
+ "gix-utils",
  "maybe-async",
  "thiserror",
  "winnow",
@@ -826,31 +775,31 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b005c550bf84de3b24aa5e540a23e6146a1c01c7d30470e35d75a12f827f969"
+checksum = "4a375a75b4d663e8bafe3bf4940a18a23755644c13582fa326e99f8f987d83fd"
 dependencies = [
  "bstr",
- "gix-utils 0.2.0",
+ "gix-utils",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-ref"
-version = "0.51.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e1f7eb6b7ce82d2d19961f74bd637bab3ea79b1bc7bfb23dbefc67b0415d8b"
+checksum = "4b7a23209d4e4cbdc2086d294f5f3f8707ac6286768847024d952d8cd3278c5b"
 dependencies = [
  "gix-actor",
- "gix-features 0.41.1",
- "gix-fs 0.14.0",
- "gix-hash 0.17.0",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
  "gix-lock",
  "gix-object",
  "gix-path",
  "gix-tempfile",
- "gix-utils 0.2.0",
- "gix-validate 0.9.4",
+ "gix-utils",
+ "gix-validate",
  "memmap2",
  "thiserror",
  "winnow",
@@ -858,29 +807,29 @@ dependencies = [
 
 [[package]]
 name = "gix-refspec"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8587b21e2264a6e8938d940c5c99662779c13a10741a5737b15fc85c252ffc"
+checksum = "7d29cae1ae31108826e7156a5e60bffacab405f4413f5bc0375e19772cce0055"
 dependencies = [
  "bstr",
- "gix-hash 0.17.0",
+ "gix-hash",
  "gix-revision",
- "gix-validate 0.9.4",
+ "gix-validate",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-revision"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342caa4e158df3020cadf62f656307c3948fe4eacfdf67171d7212811860c3e9"
+checksum = "f651f2b1742f760bb8161d6743229206e962b73d9c33c41f4e4aefa6586cbd3d"
 dependencies = [
  "bitflags",
  "bstr",
  "gix-commitgraph",
  "gix-date",
- "gix-hash 0.17.0",
+ "gix-hash",
  "gix-hashtable",
  "gix-object",
  "gix-revwalk",
@@ -890,13 +839,13 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc7c3d7e5cdc1ab8d35130106e4af0a4f9f9eca0c81f4312b690780e92bde0d"
+checksum = "06e74f91709729e099af6721bd0fa7d62f243f2005085152301ca5cdd86ec02c"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
- "gix-hash 0.17.0",
+ "gix-hash",
  "gix-hashtable",
  "gix-object",
  "smallvec",
@@ -905,35 +854,35 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.10.12"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aeb0f13de9ef2f3033f5ff218de30f44db827ac9f1286f9ef050aacddd5888"
+checksum = "09f7053ed7c66633b56c57bc6ed3377be3166eaf3dc2df9f1c5ec446df6fdf2c"
 dependencies = [
  "bitflags",
  "gix-path",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "gix-shallow"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc0598aacfe1d52575a21c9492fee086edbb21e228ec36c819c42ab923f434c3"
+checksum = "d936745103243ae4c510f19e0760ce73fb0f08096588fdbe0f0d7fb7ce8944b7"
 dependencies = [
  "bstr",
- "gix-hash 0.17.0",
+ "gix-hash",
  "gix-lock",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-tempfile"
-version = "17.1.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c750e8c008453a2dba67a2b0d928b7716e05da31173a3f5e351d5457ad4470aa"
+checksum = "666c0041bcdedf5fa05e9bef663c897debab24b7dc1741605742412d1d47da57"
 dependencies = [
- "gix-fs 0.15.0",
+ "gix-fs",
  "libc",
  "once_cell",
  "parking_lot",
@@ -942,19 +891,19 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c396a2036920c69695f760a65e7f2677267ccf483f25046977d87e4cb2665f7"
+checksum = "e2ccaf54b0b1743a695b482ca0ab9d7603744d8d10b2e5d1a332fef337bee658"
 
 [[package]]
 name = "gix-transport"
-version = "0.46.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f68c2870bfca8278389d2484a7f2215b67d0b0cc5277d3c72ad72acf41787e"
+checksum = "12f7cc0179fc89d53c54e1f9ce51229494864ab4bf136132d69db1b011741ca3"
 dependencies = [
  "bstr",
  "gix-command",
- "gix-features 0.41.1",
+ "gix-features",
  "gix-packetline",
  "gix-quote",
  "gix-sec",
@@ -964,14 +913,14 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.45.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c0b049f8bdb61b20016694102f7b507f2e1727e83e9c5e6dad4f7d84ff7384"
+checksum = "c7cdc82509d792ba0ad815f86f6b469c7afe10f94362e96c4494525a6601bdd5"
 dependencies = [
  "bitflags",
  "gix-commitgraph",
  "gix-date",
- "gix-hash 0.17.0",
+ "gix-hash",
  "gix-hashtable",
  "gix-object",
  "gix-revwalk",
@@ -981,26 +930,16 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dfe23f93f1ddb84977d80bb0dd7aa09d1bf5d5afc0c9b6820cccacc25ae860"
+checksum = "1b76a9d266254ad287ffd44467cd88e7868799b08f4d52e02d942b93e514d16f"
 dependencies = [
  "bstr",
- "gix-features 0.41.1",
+ "gix-features",
  "gix-path",
  "percent-encoding",
  "thiserror",
  "url",
-]
-
-[[package]]
-name = "gix-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189f8724cf903e7fd57cfe0b7bc209db255cacdcb22c781a022f52c3a774f8d0"
-dependencies = [
- "fastrand",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -1011,16 +950,6 @@ checksum = "5351af2b172caf41a3728eb4455326d84e0d70fe26fc4de74ab0bd37df4191c5"
 dependencies = [
  "fastrand",
  "unicode-normalization",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5f1253109da6c79ed7cf6e1e38437080bb6d704c76af14c93e2f255234084"
-dependencies = [
- "bstr",
- "thiserror",
 ]
 
 [[package]]
@@ -1044,19 +973,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heapless"
@@ -1197,7 +1121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1282,6 +1206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,12 +1225,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1474,11 +1401,10 @@ dependencies = [
 
 [[package]]
 name = "prodash"
-version = "29.0.2"
+version = "30.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04bb108f648884c23b98a0e940ebc2c93c0c3b89f04dbaf7eb8256ce617d1bc"
+checksum = "5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139"
 dependencies = [
- "log",
  "parking_lot",
 ]
 
@@ -1514,19 +1440,6 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -1534,7 +1447,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -1730,7 +1643,7 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 1.0.7",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -1749,7 +1662,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.7",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -2074,7 +1987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "rustix",
 ]
 
 [[package]]
@@ -2099,26 +2012,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2174,3 +2067,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ clap = { version = "~4.5", default-features = false, features = [
 ctrlc = "3.4"
 encoding_rs = "0.8"
 flate2 = "1"
-gix = { version = "0.71", default-features = false, features = [
+gix = { version = "0.73", default-features = false, features = [
   "command",
   "revision",
 ] }

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -233,7 +233,12 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
         replacements.insert("authemail", Cow::Borrowed(author.email));
         replacements.insert(
             "authdate",
-            Cow::Owned(author.time.format(gix::date::time::format::ISO8601).into()),
+            Cow::Owned(
+                author
+                    .time()?
+                    .format(gix::date::time::format::ISO8601)
+                    .into(),
+            ),
         );
         let committer = patch_commit.committer()?;
         replacements.insert("commname", Cow::Borrowed(committer.name));
@@ -242,7 +247,7 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
             "commdate",
             Cow::Owned(
                 committer
-                    .time
+                    .time()?
                     .format(gix::date::time::format::ISO8601)
                     .into(),
             ),

--- a/src/cmd/import.rs
+++ b/src/cmd/import.rs
@@ -599,10 +599,10 @@ fn create_patch<'repo>(
             gix::actor::Signature {
                 name: BString::from(name),
                 email: BString::from(email),
-                time: default_author.time,
+                time: default_author.time()?,
             }
         } else {
-            default_author.to_owned()
+            default_author.to_owned()?
         }
     };
 

--- a/src/cmd/pick.rs
+++ b/src/cmd/pick.rs
@@ -314,11 +314,11 @@ fn pick_picks(
         let author = commit.author_strict()?;
         let default_committer = stack.repo.get_committer()?;
         let committer = if matches.get_flag("committer-date-is-author-date") {
-            let mut committer = default_committer.to_owned();
+            let mut committer = default_committer.to_owned()?;
             committer.time = author.time;
             committer
         } else {
-            default_committer.to_owned()
+            default_committer.to_owned()?
         };
         let parent = if let Some(parent) = opt_parent.as_ref() {
             parent.clone()
@@ -332,8 +332,8 @@ fn pick_picks(
             (commit.clone(), parent)
         };
         let new_commit_id = stack.repo.commit_ex(
-            &author,
-            &committer,
+            author.to_ref(&mut gix::date::parse::TimeBuf::default()),
+            committer.to_ref(&mut gix::date::parse::TimeBuf::default()),
             message,
             top.tree_id()?.detach(),
             [bottom.id],

--- a/src/cmd/refresh.rs
+++ b/src/cmd/refresh.rs
@@ -181,7 +181,9 @@ fn run(matches: &ArgMatches) -> Result<()> {
 
     // Make temp patch
     let temp_commit_id = stack.repo.commit_ex(
-        &repo.get_author()?.override_author(matches),
+        repo.get_author()?
+            .override_author(matches)
+            .to_ref(&mut gix::date::parse::TimeBuf::default()),
         repo.get_committer()?,
         &Message::from(format!("Refresh of {patchname}")),
         tree_id,

--- a/src/cmd/spill.rs
+++ b/src/cmd/spill.rs
@@ -101,16 +101,16 @@ fn run(matches: &ArgMatches) -> Result<()> {
     let author = patch_commit.author_strict()?;
     let default_committer = repo.get_committer()?;
     let committer = if matches.get_flag("committer-date-is-author-date") {
-        let mut committer = default_committer.to_owned();
+        let mut committer = default_committer.to_owned()?;
         committer.time = author.time;
         committer
     } else {
-        default_committer.to_owned()
+        default_committer.to_owned()?
     };
 
     let commit_id = repo.commit_ex(
-        &author,
-        &committer,
+        author.to_ref(&mut gix::date::parse::TimeBuf::default()),
+        committer.to_ref(&mut gix::date::parse::TimeBuf::default()),
         &patch_commit.message_ex(),
         tree_id,
         patch_commit_ref.parents(),

--- a/src/cmd/sync.rs
+++ b/src/cmd/sync.rs
@@ -225,15 +225,15 @@ fn run(matches: &clap::ArgMatches) -> Result<()> {
                     let author = commit.author_strict()?;
                     let default_committer = trans.repo().get_committer()?;
                     let committer = if matches.get_flag("committer-date-is-author-date") {
-                        let mut committer = default_committer.to_owned();
+                        let mut committer = default_committer.to_owned()?;
                         committer.time = author.time;
                         committer
                     } else {
-                        default_committer.to_owned()
+                        default_committer.to_owned()?
                     };
                     let commit_id = trans.repo().commit_ex(
-                        &author,
-                        &committer,
+                        author.to_ref(&mut gix::date::parse::TimeBuf::default()),
+                        committer.to_ref(&mut gix::date::parse::TimeBuf::default()),
                         &commit.message_ex(),
                         tree_id,
                         [parent_id],

--- a/src/ext/commit.rs
+++ b/src/ext/commit.rs
@@ -53,7 +53,7 @@ impl<'a> CommitExtended<'a> for gix::Commit<'a> {
                 Ok(gix::actor::Signature {
                     name: BString::from(name.as_ref()),
                     email: BString::from(email.as_ref()),
-                    time: sig.time,
+                    time: sig.time()?,
                 })
             } else {
                 Err(anyhow!(

--- a/src/ext/repository.rs
+++ b/src/ext/repository.rs
@@ -256,8 +256,8 @@ impl RepositoryExtended for gix::Repository {
             let commit_id = self.write_object(&gix::objs::Commit {
                 tree: tree_id,
                 parents: parent_ids.into_iter().collect(),
-                author: author.to_owned(),
-                committer: committer.to_owned(),
+                author: author.to_owned()?,
+                committer: committer.to_owned()?,
                 encoding: commit_encoding.map(|enc| enc.name().into()),
                 message: message.raw_bytes().into(),
                 extra_headers: vec![],

--- a/src/patch/edit/mod.rs
+++ b/src/patch/edit/mod.rs
@@ -273,7 +273,8 @@ impl<'a, 'repo> EditBuilder<'a, 'repo> {
             // existing patch commit's author is broken, but only if the author
             // signature has to be derived from that commit.
             let patch_commit = patch_commit.expect("existing patch or author overlay is required");
-            if let Some(args_author) = author_from_args(matches, Some(patch_commit.author()?.time))?
+            if let Some(args_author) =
+                author_from_args(matches, Some(patch_commit.author()?.time()?))?
             {
                 Some(args_author)
             } else {
@@ -473,7 +474,7 @@ impl<'a, 'repo> EditBuilder<'a, 'repo> {
                 Some(None) => Some(if let Some(commit) = patch_commit {
                     commit.author_strict()?
                 } else {
-                    repo.get_author()?.to_owned()
+                    repo.get_author()?.to_owned()?
                 }),
                 None => patch_description.author.take(),
             };
@@ -543,11 +544,11 @@ impl<'a, 'repo> EditBuilder<'a, 'repo> {
         };
 
         let committer = if matches.get_flag("committer-date-is-author-date") {
-            let mut committer = default_committer.to_owned();
+            let mut committer = default_committer.to_owned()?;
             committer.time = author.time;
             committer
         } else {
-            default_committer.to_owned()
+            default_committer.to_owned()?
         };
 
         let new_commit_id = if patch_commit
@@ -558,14 +559,22 @@ impl<'a, 'repo> EditBuilder<'a, 'repo> {
                 // N.B.: intentionally not comparing commiter.when()
                 && patch_commit_ref.author().name == author.name
                 && patch_commit_ref.author().email == author.email
-                && patch_commit_ref.author().time == author.time
+                && patch_commit_ref.author().time == author.time.to_str(
+                    &mut gix::date::parse::TimeBuf::default()
+                )
                 && patch_commit_ref.message == message.raw_bytes()
                 && patch_commit_ref.tree() == tree_id
                 && patch_commit_ref.parents().next() == Some(parent_id)
             }) {
             None
         } else {
-            Some(repo.commit_ex(&author, &committer, &message, tree_id, [parent_id])?)
+            Some(repo.commit_ex(
+                author.to_ref(&mut gix::date::parse::TimeBuf::default()),
+                committer.to_ref(&mut gix::date::parse::TimeBuf::default()),
+                &message,
+                tree_id,
+                [parent_id],
+            )?)
         };
 
         let new_patchname = if original_patchname.as_ref() == Some(&patchname) {

--- a/src/stack/transaction/mod.rs
+++ b/src/stack/transaction/mod.rs
@@ -558,17 +558,17 @@ impl<'repo> StackTransaction<'repo> {
             let author = patch_commit.author_strict()?;
             let default_committer = repo.get_committer()?;
             let committer = if self.options.committer_date_is_author_date {
-                let mut committer = default_committer.to_owned();
+                let mut committer = default_committer.to_owned()?;
                 committer.time = author.time;
                 committer
             } else {
-                default_committer.to_owned()
+                default_committer.to_owned()?
             };
             let message = patch_commit.message_ex();
             let parent_ids = [self.top().id];
             let new_commit_id = repo.commit_ex(
-                &author,
-                &committer,
+                author.to_ref(&mut gix::date::parse::TimeBuf::default()),
+                committer.to_ref(&mut gix::date::parse::TimeBuf::default()),
                 &message,
                 patch_commit.tree_id()?.detach(),
                 parent_ids,
@@ -1111,15 +1111,15 @@ impl<'repo> StackTransaction<'repo> {
         if new_tree_id != patch_commit_ref.tree() || new_parent.id != old_parent.id {
             let author = patch_commit.author_strict()?;
             let committer = if self.options.committer_date_is_author_date {
-                let mut committer = default_committer.to_owned();
+                let mut committer = default_committer.to_owned()?;
                 committer.time = author.time;
                 committer
             } else {
-                default_committer.to_owned()
+                default_committer.to_owned()?
             };
             let commit_id = repo.commit_ex(
-                &author,
-                &committer,
+                author.to_ref(&mut gix::date::parse::TimeBuf::default()),
+                committer.to_ref(&mut gix::date::parse::TimeBuf::default()),
                 &patch_commit.message_ex(),
                 new_tree_id,
                 [new_parent.id],

--- a/src/stupid/context.rs
+++ b/src/stupid/context.rs
@@ -419,11 +419,11 @@ impl StupidContext<'_, '_> {
             // TODO: re-encode dates?
             .env(
                 "GIT_AUTHOR_DATE",
-                author.time.format(gix::date::time::format::RAW),
+                author.time()?.format(gix::date::time::format::RAW),
             )
             .env(
                 "GIT_COMMITTER_DATE",
-                committer.time.format(gix::date::time::format::RAW),
+                committer.time()?.format(gix::date::time::format::RAW),
             )
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())


### PR DESCRIPTION
This PR tries to update `gix` to version 0.73.

The changes were needed because of:

* [`SignatureRef.time`](https://docs.rs/gix-actor/0.35.2/gix_actor/struct.SignatureRef.html#method.time) method now returns a `&str`. There is a [`SignatureRef.time()`](https://docs.rs/gix-actor/0.35.2/gix_actor/struct.SignatureRef.html#method.time) to get [`Time`](https://docs.rs/gix-date/0.10.3/gix_date/struct.Time.html) back. This can however fail and return an Error. I replaced all instances where `time` was accessed directly with `time()?`. In one case, I couldn't use the `?` operator because the method did not return a `Result`. How do you want this to be handled? Is there some default value that can be used here? The compile error looks like this:

```
> cargo b
   Compiling stgit v2.5.3 (/home/hka/dev/opensource/stgit)
error[E0308]: mismatched types
  --> src/ext/signature.rs:49:24
   |
49 |             .unwrap_or(self.time);
   |              --------- ^^^^^^^^^ expected `Time`, found `&str`
   |              |
   |              arguments to this method are incorrect
   |
help: the return type of this call is `&str` due to the type of the argument passed
  --> src/ext/signature.rs:46:20
   |
46 |           let time = matches
   |  ____________________^
47 | |             .get_one::<gix::date::Time>("authdate")
48 | |             .copied()
49 | |             .unwrap_or(self.time);
   | |________________________---------^
   |                          |
   |                          this argument influences the return type of `unwrap_or`
note: method defined here
  --> /builddir/build/BUILD/rust-1.88.0-build/rustc-1.88.0-src/library/core/src/option.rs:1023:12
```

* [`SignatureRef.to_owned()`](https://docs.rs/gix-actor/0.35.2/gix_actor/struct.SignatureRef.html#method.to_owned) can now fail and needs to handled accordingly (by using the `?` operator).
* [`RepositoryExtended.commit_ex()`](https://github.com/stacked-git/stgit/blob/master/src/ext/repository.rs#L56) wants a `SignatureRef` but `Signature` was passed. I assume that because of the updated somewhere `Signature` is returned instead of `SignatureRef`. I added a couple of `Signature.to_ref` calls where needed.