### PR TITLE
feat: write .stgit-edit.txt to .git directory instead of current working directory

### DIFF
--- a/src/cmd/rebase.rs
+++ b/src/cmd/rebase.rs
@@ -367,16 +367,16 @@ fn interactive_pushback(
         return Ok(());
     }
 
-    let filename = ".stgit-rebase-interactive.txt";
+    let filename = stack.repo.git_data_file(".stgit-rebase-interactive.txt");
     std::fs::write(
-        filename,
+        &filename,
         make_instructions_template(&stack, previously_applied),
     )?;
 
-    let buf = patchedit::call_editor(filename, config)?;
+    let buf = patchedit::call_editor(&filename, config)?;
     let buf = buf
         .to_str()
-        .map_err(|_| anyhow!("`{filename}` is not valid UTF-8"))?;
+        .map_err(|_| anyhow!("`{}` is not valid UTF-8", filename.display()))?;
     let mut instructions = parse_instructions(buf)?;
 
     validate_instructions(&stack, &instructions)?;

--- a/src/ext/repository.rs
+++ b/src/ext/repository.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 use std::borrow::Cow;
+use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
 use bstr::BStr;
@@ -78,6 +79,13 @@ pub(crate) trait RepositoryExtended {
 
     /// [`gix::Repository::rev_parse_single()`] with StGit-specific error mapping.
     fn rev_parse_single_ex(&self, spec: &str) -> Result<gix::Id<'_>>;
+
+    /// Get path to a file in the git directory.
+    ///
+    /// By default, this returns a path within the `.git` directory to avoid cluttering
+    /// the working directory. If the `STG_EDIT_IN_CWD` environment variable is set,
+    /// returns the path relative to the current working directory instead.
+    fn git_data_file(&self, path: &str) -> PathBuf;
 }
 
 /// Options for creating a git commit object.
@@ -329,5 +337,13 @@ impl RepositoryExtended for gix::Repository {
                     }
                 }
             })
+    }
+
+    fn git_data_file(&self, path: &str) -> PathBuf {
+        // If STG_EDIT_IN_CWD is set, return path as is.
+        match std::env::var("STG_EDIT_IN_CWD") {
+            Ok(_) => PathBuf::from(path),
+            Err(_) => self.path().join(path),
+        }
     }
 }

--- a/src/patch/edit/interactive.rs
+++ b/src/patch/edit/interactive.rs
@@ -38,19 +38,21 @@ pub(super) fn edit_interactive(
     patch_desc: &EditablePatchDescription,
     config: &gix::config::Snapshot,
 ) -> Result<EditedPatchDescription> {
-    let filename = if patch_desc.diff.is_some() {
+    use crate::ext::RepositoryExtended;
+
+    let filename = config.repo.git_data_file(if patch_desc.diff.is_some() {
         EDIT_FILE_NAME_DIFF
     } else {
         EDIT_FILE_NAME
-    };
+    });
 
     {
-        let file = File::create(filename)?;
+        let file = File::create(&filename)?;
         let mut stream = BufWriter::new(file);
         patch_desc.write(&mut stream)?;
     }
 
-    let buf = call_editor(filename, config)?;
+    let buf = call_editor(&filename, config)?;
     let edited_desc = EditedPatchDescription::try_from(buf.as_slice())?;
     Ok(edited_desc)
 }


### PR DESCRIPTION
Follow git's convention of keeping interactive edit files in the `.git` directory. 
Avoid writing .stgit-edit.txt files to the working tree.