### PR TITLE
Bugfix: issue #615, add Copied variant to Status enum and move panic to a copied status, add integration test

### DIFF
--- a/src/stupid/status.rs
+++ b/src/stupid/status.rs
@@ -653,7 +653,7 @@ mod tests {
         assert_eq!(iter.next().unwrap().path(), Path::new("file1"));
         assert_eq!(iter.next().unwrap().path(), Path::new("file 3"));
         assert_eq!(iter.next().unwrap().path(), Path::new("file-2"));
-        let copied_entry = iter.next().unwrap();
+        let copied_entry = iter.next().expect("copied entry should be present");
         assert_eq!(copied_entry.path(), Path::new("file1-copy"));
         assert!(matches!(copied_entry.index_status(), Status::Unmodified));
         assert!(matches!(copied_entry.worktree_status(), Status::Copied));

--- a/t/t2700-refresh.sh
+++ b/t/t2700-refresh.sh
@@ -201,4 +201,16 @@ test_expect_success 'Attempt refresh with open conflict' '
     grep -e "resolve outstanding conflicts first" err
 '
 
+test_expect_success 'Refresh with copied file' '
+    stg undo --hard &&
+    stg pop -a &&
+    stg push p0 &&
+    git config status.renames copies &&
+    stg new p-copy -m "copy test" &&
+    cp foo1.txt foo1-copy.txt &&
+    git add foo1-copy.txt &&
+    stg refresh &&
+    git config --unset status.renames
+'
+
 test_done


### PR DESCRIPTION
Fixes #615 

The crash only occurs in a specific code path. `Status::from_char()` is called lazily.

This happens only when `entry.index_status()` or `entry.worktree_status()` is accessed in `determine_refresh_paths()` inside the `if !force` guard that checks whether the index and worktree are independently clean.

Using `stg refresh --force` skips this check entirely, hiding the bug.

I also added tests.

Notes:
- The C status only appears in porcelain v2 when `status.renames=copies` is configured
- `--force` skips the `determine_refresh_paths` dirty check loop, which is the only code path that calls `Status::from_char`. Thus, the panic only occurs without --force
- The `StatusEntryKind` parsing already handles copies correctly (entry kind 2, same as renames)

### This is a bit of a drive-by, I might be missing something but I think this is correct? Let me know if its just off or I am missing anything and can do further work
