### PR TITLE
stgit.el: Fix Index/Work Tree incremental refresh

### DIFF
--- a/contrib/stgit.el
+++ b/contrib/stgit.el
@@ -573,18 +573,21 @@ been advised to update the stgit status when necessary.")
     (ewoc-invalidate (car stgit-worktree-node) (cdr stgit-worktree-node))))
 
 (defun stgit-run-series-insert-index (ewoc)
-  (setq stgit-index-node    (cons ewoc (ewoc-enter-last ewoc
-                                                        (make-stgit-patch
-                                                         :status 'index
-                                                         :name :index
-                                                         :desc nil
-                                                         :empty nil)))
-        stgit-worktree-node (cons ewoc (ewoc-enter-last ewoc
-                                                        (make-stgit-patch
-                                                         :status 'work
-                                                         :name :work
-                                                         :desc nil
-                                                         :empty nil)))))
+  (let ((index-node (ewoc-enter-last ewoc
+                                     (make-stgit-patch
+                                      :status 'index
+                                      :name :index
+                                      :desc nil
+                                      :empty nil)))
+        (worktree-node (ewoc-enter-last ewoc
+                                        (make-stgit-patch
+                                         :status 'work
+                                         :name :work
+                                         :desc nil
+                                         :empty nil))))
+    (with-current-buffer (ewoc--buffer ewoc)
+      (setq stgit-index-node (cons ewoc index-node)
+            stgit-worktree-node (cons ewoc worktree-node)))))
 
 (defun stgit-get-position (&optional position)
   "Return position information at POSITION or point that can be restored later.


### PR DESCRIPTION
Index/Work Tree incremental refresh has been broken in center mode after lexical-binding change made in commit 04559f055298df4485116640a3ea76b8e860a0f5.

When stgit-show-worktree-mode is center, stgit-run-series-insert-index may be called while parsing stg series output inside with-temp-buffer. Since stgit-index-node and stgit-worktree-node are buffer-local, the current implementation stores them in the temporary buffer, not the real stgit-mode buffer.

As a result, after reload in this layout:

stgit-index-node    ;; nil in the stgit buffer
stgit-worktree-node ;; nil in the stgit buffer

Then commands like stgit-toggle-index call:

(stgit-refresh-worktree)
(stgit-refresh-index)

but both are no-ops because the node variables are nil. A full stgit-reload still works, which is why pressing g fixes the display.

Fix by applying the updated stgit-index-node and stgit-worktree-node to the real stgit-mode buffer instead.

Fixes: 04559f055298df4485116640a3ea76b8e860a0f5
Fixes: #633