### PR TITLE
fix(rebase): Run --exec commands also if the stack base does not change

### DIFF
--- a/src/cmd/rebase.rs
+++ b/src/cmd/rebase.rs
@@ -121,6 +121,10 @@ fn run(matches: &ArgMatches) -> Result<()> {
     let allow_push_conflicts = argset::resolve_allow_push_conflicts(&config, matches);
     let committer_date_is_author_date = matches.get_flag("committer-date-is-author-date");
     let interactive = matches.get_flag("interactive");
+    let exec_cmds: Vec<&str> = matches
+        .get_many::<String>("exec")
+        .map(|vals| vals.map(String::as_str).collect())
+        .unwrap_or_default();
 
     let target_commit = if let Some(target_rev_spec) =
         matches.get_one::<SingleRevisionSpec>("committish")
@@ -149,7 +153,7 @@ fn run(matches: &ArgMatches) -> Result<()> {
         ));
     };
 
-    if !interactive && target_commit.id == stack.base().id {
+    if !interactive && exec_cmds.is_empty() && target_commit.id == stack.base().id {
         print_info_message(
             matches,
             &format!(
@@ -259,10 +263,6 @@ fn run(matches: &ArgMatches) -> Result<()> {
     } else if !matches.get_flag("nopush") {
         stack.check_head_top_mismatch()?;
         let check_merged = matches.get_flag("merged");
-        let exec_cmds: Vec<&str> = matches
-            .get_many::<String>("exec")
-            .map(|vals| vals.map(String::as_str).collect())
-            .unwrap_or_default();
 
         stack
             .setup_transaction()

--- a/t/t2206-rebase-exec.sh
+++ b/t/t2206-rebase-exec.sh
@@ -30,6 +30,13 @@ test_expect_success 'Rebase with --exec runs command after each patch' '
     test $(wc -l <exec.log) = 3
 '
 
+test_expect_success 'Rebase on {base} with --exec runs command after each patch' '
+    rm -f exec.log &&
+    stg rebase --exec "echo EXEC >>exec.log" {base} &&
+    test $(stg series --applied -c) = 3 &&
+    test $(wc -l <exec.log) = 3
+'
+
 test_expect_success 'Rebase with multiple --exec options' '
     rm -f exec.log exec2.log &&
     stg rebase --exec "echo EXEC1 >>exec.log" --exec "echo EXEC2 >>exec2.log" master~1 &&


### PR DESCRIPTION
`stg rebase --exec` is modeled after `git rebase --exec`. However, `stg rebase --exec cmd {base}` short-circuits the rebase entirely since the stack base does not change.  This diverges from `git rebase` behavior which execute commands in a similar scenario `git rebase --onto $(stg id {base}) $(stg id {base}) mybranch`.  Make stgit behave like git by removing the short-ciruiting if `--exec` is specified.

Fixes: #638 